### PR TITLE
Fix crash and add start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ $ git clone https://github.com/your‑handle/villagesim.git
 $ cd villagesim
 
 # Create and activate a virtual environment
-$ python -m venv .venv
+$ python3 -m venv .venv
 $ source .venv/bin/activate            # Windows: .venv\Scripts\activate
 
 # Install dependencies
 $ pip install -r requirements.txt
 
 # Run the game
-$ python -m src.main [--seed 42] [--show-fps] [-v]
+$ python3 -m src.main [--seed 42] [--show-fps] [-v]
 ```
 
 ### Default Controls

--- a/src/game.py
+++ b/src/game.py
@@ -330,8 +330,6 @@ class Game:
                 vill.update(self)
             self.tick_count += 1
             self.single_step = False
-            elif key.lower() == "q":
-                self.running = False
 
         # Process pending villager spawns
         self._process_spawns()

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Setup virtual environment (if needed) and run the game
+set -e
+
+VENV_DIR="venv"
+
+if [ ! -d "$VENV_DIR" ]; then
+    python3 -m venv "$VENV_DIR"
+    source "$VENV_DIR/bin/activate"
+    pip install -r requirements.txt
+else
+    source "$VENV_DIR/bin/activate"
+fi
+
+python3 -m src.main "$@"


### PR DESCRIPTION
## Summary
- fix invalid syntax in game loop
- update README instructions to use python3
- add `start.sh` helper to create venv and run the game

## Testing
- `pytest -q` *(fails: command not found)*
- `python3 -m src.main --seed 42 --show-fps -v` *(fails: '_curses.window' object has no attribute 'inkey')*