### PR TITLE
Fix curses render_status width

### DIFF
--- a/src/renderer.py
+++ b/src/renderer.py
@@ -159,9 +159,15 @@ class Renderer:
 
     def render_status(self, text: str) -> None:
         """Render a status line at the bottom of the screen."""
-        line = text.ljust(self.term.width)
         if self.use_curses:
-            self.term.addstr(STATUS_PANEL_Y, 0, line[: self.term.width])
+            height, width = self.term.getmaxyx()
+        else:
+            width = self.term.width
+
+        line = text.ljust(width)
+
+        if self.use_curses:
+            self.term.addstr(STATUS_PANEL_Y, 0, line[:width])
             self.term.refresh()
         else:
             sys.stdout.write(self.term.move_xy(0, STATUS_PANEL_Y) + line)


### PR DESCRIPTION
## Summary
- fix curses support in renderer.render_status by using `getmaxyx()`

## Testing
- `python3 -m src.main --seed 42 --show-fps -v` *(fails: cbreak() returned ERR)*
- `pytest -q` *(fails: command not found)*