### PR TITLE
Add zoom shortcuts and villager action display

### DIFF
--- a/src/camera.py
+++ b/src/camera.py
@@ -53,6 +53,10 @@ class Camera:
         if self.zoom_index > 0:
             self.zoom_index -= 1
 
+    def set_zoom_level(self, index: int) -> None:
+        """Set zoom to a specific index within bounds."""
+        self.zoom_index = max(0, min(index, len(ZOOM_LEVELS) - 1))
+
     def world_to_screen(self, wx: int, wy: int) -> tuple[int, int]:
         """Translate world coordinates to screen coordinates."""
         sx = (wx - self.x) * self.zoom

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,11 +4,13 @@ from enum import Enum, auto
 MAP_WIDTH = 1000
 MAP_HEIGHT = 1000
 
+
 class TileType(Enum):
     GRASS = auto()
     TREE = auto()
     ROCK = auto()
     WATER = auto()
+
 
 # Camera defaults
 VIEWPORT_WIDTH = 80

--- a/src/game.py
+++ b/src/game.py
@@ -180,6 +180,7 @@ class Game:
         self.paused = False
         self.single_step = False
         self.show_help = False
+        self.show_actions = False
         self.show_fps = False
         self.current_fps = 0.0
         self.last_tick_ms = 0.0
@@ -302,6 +303,7 @@ class Game:
         term = self.renderer.term
         if self.renderer.use_curses:
             import curses
+
             ch = term.getch()
             key = ch if ch != -1 else None
         else:
@@ -317,21 +319,26 @@ class Game:
                     self.camera.move(0, -1, self.map.width, self.map.height)
                 elif key == curses.KEY_DOWN:
                     self.camera.move(0, 1, self.map.width, self.map.height)
-                elif key == ord('+'):
+                elif key == ord("+"):
                     self.camera.zoom_in()
                     self.camera.move(0, 0, self.map.width, self.map.height)
-                elif key == ord('-'):
+                elif key == ord("-"):
                     self.camera.zoom_out()
                     self.camera.move(0, 0, self.map.width, self.map.height)
-                elif key == ord(' '):
+                elif ord("1") <= key <= ord("9"):
+                    self.camera.set_zoom_level(key - ord("1"))
+                    self.camera.move(0, 0, self.map.width, self.map.height)
+                elif key == ord(" "):
                     self.paused = not self.paused
-                elif key == ord('.'):
+                elif key == ord("."):
                     self.single_step = True
-                elif key in (ord('h'), ord('H')):
+                elif key in (ord("h"), ord("H")):
                     self.show_help = not self.show_help
-                elif key in (ord('c'), ord('C')):
+                elif key in (ord("a"), ord("A")):
+                    self.show_actions = not self.show_actions
+                elif key in (ord("c"), ord("C")):
                     self.camera.center(self.map.width, self.map.height)
-                elif key in (ord('q'), ord('Q')):
+                elif key in (ord("q"), ord("Q")):
                     self.running = False
             else:
                 if key.code == term.KEY_LEFT:
@@ -348,15 +355,20 @@ class Game:
                 elif key == "-":
                     self.camera.zoom_out()
                     self.camera.move(0, 0, self.map.width, self.map.height)
-                elif key == ' ':
+                elif key in "123456789":
+                    self.camera.set_zoom_level(int(key) - 1)
+                    self.camera.move(0, 0, self.map.width, self.map.height)
+                elif key == " ":
                     self.paused = not self.paused
-                elif key == '.':
+                elif key == ".":
                     self.single_step = True
-                elif key.lower() == 'h':
+                elif key.lower() == "h":
                     self.show_help = not self.show_help
-                elif key.lower() == 'c':
+                elif key.lower() == "a":
+                    self.show_actions = not self.show_actions
+                elif key.lower() == "c":
                     self.camera.center(self.map.width, self.map.height)
-                elif key.lower() == 'q':
+                elif key.lower() == "q":
                     self.running = False
 
         if not self.paused or self.single_step:
@@ -420,8 +432,21 @@ class Game:
         if self.show_help:
             lines = [
                 "Controls:",
-                "arrow keys - move camera", "+/- - zoom", "space - pause",
-                ". - step", "c - centre", "h - toggle help", "q - quit",
+                "arrow keys - move camera",
+                "+/- - zoom",
+                "space - pause",
+                ". - step",
+                "c - centre",
+                "h - toggle help",
+                "q - quit",
+                "1-9 - set zoom",
+                "a - toggle actions",
             ]
             self.renderer.render_help(lines)
 
+        if self.show_actions:
+            start = 0
+            if self.show_help:
+                start = len(lines)
+            lines = [f"Villager {v.id}: {v.state}" for v in self.entities]
+            self.renderer.render_overlay(lines, start_y=start)

--- a/src/renderer.py
+++ b/src/renderer.py
@@ -184,3 +184,16 @@ class Renderer:
             self.term.refresh()
         else:
             sys.stdout.flush()
+
+    def render_overlay(self, lines: list[str], start_y: int = 0) -> None:
+        """Render generic overlay lines starting at ``start_y``."""
+        for idx, line in enumerate(lines):
+            y = start_y + idx
+            if self.use_curses:
+                self.term.addstr(y, 0, line)
+            else:
+                sys.stdout.write(self.term.move_xy(0, y) + line)
+        if self.use_curses:
+            self.term.refresh()
+        else:
+            sys.stdout.flush()


### PR DESCRIPTION
## Summary
- allow setting zoom level directly using keys `1`-`9`
- toggle villager action overlay with `a`
- render list of villager states on screen

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q` *(fails: No module named pytest)*