### PR TITLE
Fix stuck villager and resource pathfinding

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -159,8 +159,8 @@ class Game:
         }
         # Global resource storage
         self.storage: Dict[str, int] = {"wood": 0, "stone": 0}
-        # Storage location (centre of the map for now)
-        self.storage_pos: Tuple[int, int] = (self.map.width // 2, self.map.height // 2)
+        # Storage location (centre of the map, adjusted to a passable tile)
+        self.storage_pos: Tuple[int, int] = self._find_start_pos()
 
         self.renderer = Renderer()
         self.camera = Camera()
@@ -219,6 +219,28 @@ class Game:
         villager = Villager(id=self.next_entity_id, position=position)
         self.next_entity_id += 1
         self.entities.append(villager)
+
+    def _find_start_pos(self) -> Tuple[int, int]:
+        """Find the nearest passable tile to start the village on."""
+        origin = (self.map.width // 2, self.map.height // 2)
+        from collections import deque
+
+        q = deque([origin])
+        visited = {origin}
+        while q:
+            x, y = q.popleft()
+            if self.map.get_tile(x, y).passable:
+                return (x, y)
+            for dx, dy in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
+                nx, ny = x + dx, y + dy
+                if (
+                    0 <= nx < self.map.width
+                    and 0 <= ny < self.map.height
+                    and (nx, ny) not in visited
+                ):
+                    visited.add((nx, ny))
+                    q.append((nx, ny))
+        return origin
 
     # --- Building Helpers --------------------------------------------
     def is_area_free(

--- a/src/pathfinding.py
+++ b/src/pathfinding.py
@@ -135,6 +135,16 @@ def find_nearest_resource(
         for n in _neighbors(current, gmap):
             if n in visited:
                 continue
+            n_tile = gmap.get_tile(*n)
+            if n_tile.type is resource_type and n_tile.resource_amount > 0:
+                came_from[n] = current
+                current = n
+                path: List[Tuple[int, int]] = [current]
+                while current in came_from:
+                    current = came_from[current]
+                    path.append(current)
+                path.reverse()
+                return n, path
             if not _is_passable(n, gmap, buildings):
                 continue
             visited.add(n)


### PR DESCRIPTION
## Summary
- ensure the starting position is always on a passable tile
- allow resource search to step onto resource tiles

## Testing
- `python - <<'EOF'
from src.game import Game
print('start test after fix')
g=Game(seed=42)
vill=g.entities[0]
for i in range(12):
    vill.update(g)
    print(i, vill.state, g.storage['wood'])
EOF`
- *(fails)* `pip install pytest`