### PR TITLE
Fix house spawning and add distinct colors

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -43,6 +43,8 @@ class Color(Enum):
     TREE = auto()
     ROCK = auto()
     WATER = auto()
+    PATH = auto()
+    BUILDING = auto()
     UI = auto()
 
 

--- a/src/game.py
+++ b/src/game.py
@@ -146,7 +146,7 @@ class Game:
         self.buildings: List[Building] = []
         self.build_queue: List[Building] = []
         self.jobs: List[Job] = []
-        self.wood_threshold = 20
+        self.wood_threshold = 60
         self.house_threshold = 50
         self.next_entity_id = 2
         self.pending_spawns: List[Tuple[int, Tuple[int, int]]] = []
@@ -158,28 +158,28 @@ class Game:
                 cost=0,
                 footprint=[(0, 0)],
                 glyph="H",
-                color=Color.UI,
+                color=Color.BUILDING,
             ),
             "Lumberyard": BuildingBlueprint(
                 name="Lumberyard",
                 cost=10,
                 footprint=[(0, 0)],
                 glyph="L",
-                color=Color.UI,
+                color=Color.BUILDING,
             ),
             "House": BuildingBlueprint(
                 name="House",
                 cost=15,
                 footprint=[(0, 0)],
                 glyph="h",
-                color=Color.UI,
+                color=Color.BUILDING,
             ),
             "Storage": BuildingBlueprint(
                 name="Storage",
                 cost=0,
                 footprint=[(0, 0)],
                 glyph="S",
-                color=Color.UI,
+                color=Color.BUILDING,
             ),
         }
         # Global resource storage
@@ -493,7 +493,7 @@ class Game:
         if (
             self.storage["wood"] >= house_bp.cost
             and self.storage["wood"] > self.house_threshold
-            and len(self.entities) < houses * 2
+            and len(self.entities) >= houses * 2
         ):
             pos = self.find_build_site(house_bp)
             if pos:

--- a/src/renderer.py
+++ b/src/renderer.py
@@ -32,7 +32,9 @@ class Renderer:
         Color.TREE: "yellow",
         Color.ROCK: "white",
         Color.WATER: "blue",
-        Color.UI: "magenta",
+        Color.PATH: "cyan",
+        Color.BUILDING: "magenta",
+        Color.UI: "white",
     }
 
     def __init__(self) -> None:
@@ -179,7 +181,7 @@ class Renderer:
                 sx, sy = camera.world_to_screen(px, py)
                 if 0 <= sy < len(glyph_grid) and 0 <= sx < len(glyph_grid[0]):
                     glyph_grid[sy][sx] = "\xb7"  # middle dot character
-                    color_grid[sy][sx] = Color.UI
+                    color_grid[sy][sx] = Color.PATH
 
         # Overlay villagers
         for vill in villagers:


### PR DESCRIPTION
## Summary
- adjust wood gathering threshold and house building logic
- add path and building color types
- color villagers' paths cyan
- color buildings magenta instead of UI white

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q` *(fails: command not found)*