### PR TITLE
Add stone resource and finite harvesting

### DIFF
--- a/src/building.py
+++ b/src/building.py
@@ -11,10 +11,12 @@ class BuildingBlueprint:
     """Template for constructing buildings."""
 
     name: str
-    cost: int
+    build_time: int
     footprint: List[Tuple[int, int]]
     glyph: str
     color: Color
+    wood: int = 0
+    stone: int = 0
 
 
 @dataclass
@@ -35,4 +37,4 @@ class Building:
 
     @property
     def complete(self) -> bool:
-        return self.progress >= self.blueprint.cost
+        return self.progress >= self.blueprint.build_time

--- a/src/map.py
+++ b/src/map.py
@@ -44,11 +44,11 @@ class GameMap:
         if noise < 0.5:
             return Tile(TileType.GRASS, resource_amount=0, passable=True)
         if noise < 0.65:
-            amt = 5 + int(self._hash(x, y) * 15)
+            decorative = self._hash(x + 1, y + 1) < 0.1
+            amt = 0 if decorative else 100
             return Tile(TileType.TREE, resource_amount=amt, passable=False)
         if noise < 0.8:
-            amt = 3 + int(self._hash(x, y + 1) * 8)
-            return Tile(TileType.ROCK, resource_amount=amt, passable=False)
+            return Tile(TileType.ROCK, resource_amount=100, passable=False)
         return Tile(TileType.WATER, resource_amount=0, passable=False)
 
     def get_tile(self, x: int, y: int) -> Tile:

--- a/src/tile.py
+++ b/src/tile.py
@@ -23,7 +23,8 @@ class Tile:
             return 0
         removed = min(self.resource_amount, amount)
         self.resource_amount -= removed
-        # Trees/Rocks become passable when depleted
+        # Trees/Rocks disappear when depleted
         if self.resource_amount == 0 and self.type in (TileType.TREE, TileType.ROCK):
+            self.type = TileType.GRASS
             self.passable = True
         return removed


### PR DESCRIPTION
## Summary
- add wood & stone costs to building blueprints
- allow villagers to gather stone from rocks
- make trees and rocks finite and disappear when depleted
- adjust map generation for decorative trees
- track stone in storage and display it in the HUD

## Testing
- `ruff check .`
- `black --check .`
- `python -m pytest -q` *(fails: No module named pytest)*