### PR TITLE
Fix freeze by limiting BFS searches

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -35,6 +35,10 @@ VILLAGER_ACTION_DELAY = 30
 # Maximum combined resources that can be stored
 MAX_STORAGE = 100
 
+# Maximum nodes explored during breadth-first searches to avoid hangs on
+# extremely large maps.
+SEARCH_LIMIT = 10000
+
 
 class Color(Enum):
     """Logical color identifiers used for rendering."""

--- a/src/game.py
+++ b/src/game.py
@@ -13,6 +13,7 @@ from .constants import (
     TICK_RATE,
     VILLAGER_ACTION_DELAY,
     MAX_STORAGE,
+    SEARCH_LIMIT,
 )
 from .pathfinding import find_nearest_resource, find_path
 from .building import BuildingBlueprint, Building
@@ -303,8 +304,10 @@ class Game:
 
         q = deque([origin])
         visited = {origin}
-        while q:
+        searched = 0
+        while q and searched < SEARCH_LIMIT:
             x, y = q.popleft()
+            searched += 1
             if self.map.get_tile(x, y).passable:
                 return (x, y)
             for dx, dy in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
@@ -324,8 +327,10 @@ class Game:
 
         q = deque([origin])
         visited = {origin}
-        while q:
+        searched = 0
+        while q and searched < SEARCH_LIMIT:
             x, y = q.popleft()
+            searched += 1
             if self.map.get_tile(x, y).passable:
                 return (x, y)
             for dx, dy in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
@@ -381,8 +386,10 @@ class Game:
         starts = [b.position for b in self.buildings] or [self.storage_pos]
         visited = set(starts)
         q = deque(starts)
-        while q:
+        searched = 0
+        while q and searched < SEARCH_LIMIT:
             p = q.popleft()
+            searched += 1
             for dx, dy in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
                 cand = (p[0] + dx, p[1] + dy)
                 if cand in visited:
@@ -563,7 +570,6 @@ class Game:
 
         # Process pending villager spawns
         self._process_spawns()
-
 
         # Prioritise building a Quarry when possible
         quarry_bp = self.blueprints["Quarry"]

--- a/src/pathfinding.py
+++ b/src/pathfinding.py
@@ -5,7 +5,7 @@ import heapq
 from typing import Dict, List, Optional, Tuple, Iterable, Set
 
 from .map import GameMap
-from .constants import TileType
+from .constants import TileType, SEARCH_LIMIT
 
 
 @dataclass(order=True)
@@ -109,6 +109,8 @@ def find_nearest_resource(
     resource_type: TileType,
     gmap: GameMap,
     buildings: Iterable[object] | None = None,
+    *,
+    search_limit: int = SEARCH_LIMIT,
 ) -> Tuple[Optional[Tuple[int, int]], List[Tuple[int, int]]]:
     """Find the closest tile of the given resource type and a path to it."""
 
@@ -120,9 +122,13 @@ def find_nearest_resource(
     frontier = deque([start])
     came_from: Dict[Tuple[int, int], Tuple[int, int]] = {}
     visited: Set[Tuple[int, int]] = {start}
+    explored = 0
 
     while frontier:
         current = frontier.popleft()
+        explored += 1
+        if explored > search_limit:
+            break
         tile = gmap.get_tile(*current)
         if tile.type is resource_type and tile.resource_amount > 0:
             path: List[Tuple[int, int]] = [current]


### PR DESCRIPTION
## Summary
- prevent runaway BFS by limiting the number of explored nodes
- expose `SEARCH_LIMIT` constant to tune search behaviour

## Testing
- `ruff check . --fix`
- `black -q .`
- `pytest -q` *(fails: command not found)*