### PR TITLE
Fix building construction and resource gathering

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -153,6 +153,9 @@ class Villager:
                         game.build_queue.remove(self.target_building)
                     if self.target_building.blueprint.name == "House":
                         game.schedule_spawn(self.target_building.position)
+                else:
+                    # Requeue the build job until construction is finished
+                    game.jobs.append(Job("build", self.target_building))
                 self.state = "idle"
 
     @property
@@ -681,6 +684,7 @@ class Game:
             self.storage["wood"] >= lumber_bp.wood
             and self.storage["stone"] >= lumber_bp.stone
             and not any(b.blueprint.name == "Lumberyard" for b in self.build_queue)
+            and not any(b.blueprint.name == "Lumberyard" for b in self.buildings)
         ):
             pos = self.find_build_site(lumber_bp)
             if pos:

--- a/src/map.py
+++ b/src/map.py
@@ -46,9 +46,11 @@ class GameMap:
         if noise < 0.65:
             decorative = self._hash(x + 1, y + 1) < 0.1
             amt = 0 if decorative else 100
-            return Tile(TileType.TREE, resource_amount=amt, passable=False)
+            # Trees should be traversable so villagers can gather wood
+            return Tile(TileType.TREE, resource_amount=amt, passable=True)
         if noise < 0.8:
-            return Tile(TileType.ROCK, resource_amount=100, passable=False)
+            # Allow walking onto rocks for mining
+            return Tile(TileType.ROCK, resource_amount=100, passable=True)
         return Tile(TileType.WATER, resource_amount=0, passable=False)
 
     def get_tile(self, x: int, y: int) -> Tile:


### PR DESCRIPTION
## Summary
- allow villagers to walk onto trees and rocks so resources can be gathered
- requeue build jobs until construction completes
- prevent endless lumberyard construction

## Testing
- `python3 -m pytest -q` *(fails: pytest not installed)*