### PR TITLE
Refactor building blueprints

### DIFF
--- a/src/blueprints/__init__.py
+++ b/src/blueprints/__init__.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+
+from ..building import BuildingBlueprint
+
+# Dynamically load all blueprint modules in this package
+BLUEPRINTS: dict[str, BuildingBlueprint] = {}
+package_path = Path(__file__).parent
+for path in package_path.glob("*.py"):
+    if path.name == "__init__.py":
+        continue
+    module_name = f"{__name__}.{path.stem}"
+    module = import_module(module_name)
+    bp = getattr(module, "BLUEPRINT", None)
+    if isinstance(bp, BuildingBlueprint):
+        BLUEPRINTS[bp.name] = bp

--- a/src/blueprints/house.py
+++ b/src/blueprints/house.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from ..building import BuildingBlueprint
+from ..constants import Color
+
+BLUEPRINT = BuildingBlueprint(
+    name="House",
+    build_time=15,
+    footprint=[(0, 0)],
+    glyph="h",
+    color=Color.BUILDING,
+    wood=15,
+    stone=0,
+)

--- a/src/blueprints/lumberyard.py
+++ b/src/blueprints/lumberyard.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from ..building import BuildingBlueprint
+from ..constants import Color
+
+BLUEPRINT = BuildingBlueprint(
+    name="Lumberyard",
+    build_time=10,
+    footprint=[(0, 0)],
+    glyph="L",
+    color=Color.BUILDING,
+    wood=10,
+    stone=0,
+)

--- a/src/blueprints/quarry.py
+++ b/src/blueprints/quarry.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from ..building import BuildingBlueprint
+from ..constants import Color
+
+BLUEPRINT = BuildingBlueprint(
+    name="Quarry",
+    build_time=12,
+    footprint=[(0, 0)],
+    glyph="Q",
+    color=Color.BUILDING,
+    wood=10,
+    stone=10,
+)

--- a/src/blueprints/road.py
+++ b/src/blueprints/road.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from ..building import BuildingBlueprint
+from ..constants import Color
+
+BLUEPRINT = BuildingBlueprint(
+    name="Road",
+    build_time=1,
+    footprint=[(0, 0)],
+    glyph="=",
+    color=Color.PATH,
+    wood=0,
+    stone=5,
+)

--- a/src/blueprints/storage.py
+++ b/src/blueprints/storage.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from ..building import BuildingBlueprint
+from ..constants import Color
+
+BLUEPRINT = BuildingBlueprint(
+    name="Storage",
+    build_time=0,
+    footprint=[(0, 0)],
+    glyph="S",
+    color=Color.BUILDING,
+    wood=20,
+    stone=20,
+)

--- a/src/blueprints/townhall.py
+++ b/src/blueprints/townhall.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from ..building import BuildingBlueprint
+from ..constants import Color
+
+BLUEPRINT = BuildingBlueprint(
+    name="TownHall",
+    build_time=0,
+    footprint=[(0, 0)],
+    glyph="H",
+    color=Color.BUILDING,
+    wood=0,
+    stone=0,
+)

--- a/src/game.py
+++ b/src/game.py
@@ -188,62 +188,11 @@ class Game:
         self.pending_spawns: List[Tuple[int, Tuple[int, int]]] = []
 
         # Predefined blueprints
-        self.blueprints: Dict[str, BuildingBlueprint] = {
-            "TownHall": BuildingBlueprint(
-                name="TownHall",
-                build_time=0,
-                footprint=[(0, 0)],
-                glyph="H",
-                color=Color.BUILDING,
-                wood=0,
-                stone=0,
-            ),
-            "Lumberyard": BuildingBlueprint(
-                name="Lumberyard",
-                build_time=10,
-                footprint=[(0, 0)],
-                glyph="L",
-                color=Color.BUILDING,
-                wood=10,
-                stone=0,
-            ),
-            "Quarry": BuildingBlueprint(
-                name="Quarry",
-                build_time=12,
-                footprint=[(0, 0)],
-                glyph="Q",
-                color=Color.BUILDING,
-                wood=10,
-                stone=10,
-            ),
-            "House": BuildingBlueprint(
-                name="House",
-                build_time=15,
-                footprint=[(0, 0)],
-                glyph="h",
-                color=Color.BUILDING,
-                wood=15,
-                stone=0,
-            ),
-            "Storage": BuildingBlueprint(
-                name="Storage",
-                build_time=0,
-                footprint=[(0, 0)],
-                glyph="S",
-                color=Color.BUILDING,
-                wood=20,
-                stone=20,
-            ),
-            "Road": BuildingBlueprint(
-                name="Road",
-                build_time=1,
-                footprint=[(0, 0)],
-                glyph="=",
-                color=Color.PATH,
-                wood=0,
-                stone=5,
-            ),
-        }
+        # Blueprints are now loaded dynamically from ``src.blueprints`` so that
+        # adding a new building only requires creating a new module.
+        from .blueprints import BLUEPRINTS
+
+        self.blueprints: Dict[str, BuildingBlueprint] = dict(BLUEPRINTS)
         # Global resource storage
         self.storage: Dict[str, int] = {"wood": 0, "stone": 0}
         self.storage_capacity = MAX_STORAGE


### PR DESCRIPTION
## Notes
- Network access was disabled so tests requiring external packages could not run.

## Summary
- move each building blueprint into its own module under `src/blueprints`
- load blueprints dynamically in `src/blueprints/__init__.py`
- import all blueprints in `Game` constructor so adding new blueprints only requires creating a new file