### PR TITLE
Add Watchtower building

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Powered by the **blessed** TUI library (with a curses fallback), VillageSim runs
 * **Procedural Worlds** – Seedable generator carves out a diverse, resource‑rich landscape every run.
 * **Smooth ASCII Rendering** – Panning and zoom deliver crisp visuals at multiple levels of detail.
 * **Autonomous Villagers** – Agents gather, build, and deliver via an A\* path‑finding engine you can watch in real time.
-* **Dynamic Construction** – Town Halls, Lumberyards, and Houses emerge where resources allow, triggering population growth.
+* **Dynamic Construction** – Town Halls, Lumberyards, Houses, and Watchtowers emerge where resources allow, triggering population growth.
 * **Resource Economy** – Wood and stone flow through inventories, storage, and building queues.
 * **HUD & Controls** – Real‑time stats panel plus hotkeys for pause, step, help, and camera centring.
 * **Extensible & Test‑Backed** – Modular architecture, unit tests, and CI workflow encourage contribution and experimentation.
@@ -74,7 +74,7 @@ and population. Use `--show-fps` to display performance metrics.
 11. **Resource & inventory system** – Per‑agent inventory and global storage.
 12. **Gathering & delivery behaviours** – FSM: GATHER → DELIVER → IDLE.
 13. **Job dispatcher & FSM transitions** – Centralised job queue.
-14. **Building blueprints & instances** – TownHall, Lumberyard.
+14. **Building blueprints & instances** – TownHall, Lumberyard, Watchtower.
 15. **Construction queue & placement** – Auto‑placement helper, BUILD state.
 16. **Lumberyard auto‑expansion** – Resource‑driven growth logic.
 17. **House & population growth** – Housing cap and villager spawning.

--- a/src/blueprints/watchtower.py
+++ b/src/blueprints/watchtower.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from ..building import BuildingBlueprint
+from ..constants import Color
+
+BLUEPRINT = BuildingBlueprint(
+    name="Watchtower",
+    build_time=20,
+    footprint=[(0, 0)],
+    glyph="T",
+    color=Color.BUILDING,
+    wood=30,
+    stone=5,
+)

--- a/src/game.py
+++ b/src/game.py
@@ -78,7 +78,11 @@ class Villager:
                     job.payload if isinstance(job.payload, TileType) else TileType.TREE
                 )
                 pos, path = find_nearest_resource(
-                    self.position, resource_type, game.map, game.buildings
+                    self.position,
+                    resource_type,
+                    game.map,
+                    game.buildings,
+                    search_limit=game.get_search_limit(),
                 )
                 if pos is None:
                     return
@@ -371,6 +375,15 @@ class Game:
                 if tile.type is resource and tile.resource_amount > 0:
                     count += 1
         return count
+
+    def get_search_limit(self) -> int:
+        """Return BFS search limit factoring in built Watchtowers."""
+        bonus = sum(
+            1
+            for b in self.buildings
+            if b.blueprint.name == "Watchtower" and b.complete
+        )
+        return SEARCH_LIMIT + bonus * 5000
 
     # --- Building Helpers --------------------------------------------
     def is_area_free(

--- a/tests/test_watchtower.py
+++ b/tests/test_watchtower.py
@@ -1,0 +1,20 @@
+from src.blueprints import BLUEPRINTS
+from src.game import Game
+from src.building import Building
+
+
+def test_watchtower_blueprint_loaded():
+    assert "Watchtower" in BLUEPRINTS
+    bp = BLUEPRINTS["Watchtower"]
+    assert bp.glyph == "T"
+
+
+def test_watchtower_increases_search_limit():
+    game = Game(seed=42)
+    base_limit = game.get_search_limit()
+    bp = game.blueprints["Watchtower"]
+    b = Building(bp, (game.townhall_pos[0] + 2, game.townhall_pos[1]))
+    b.progress = bp.build_time
+    b.passable = False
+    game.buildings.append(b)
+    assert game.get_search_limit() > base_limit


### PR DESCRIPTION
## Summary
- add a Watchtower blueprint
- expand README to mention Watchtowers
- increase resource search radius when Watchtowers are built
- test blueprint loading and search limit

## Testing
- `pytest -q` *(fails: command not found)*