### PR TITLE
Show building progress during construction

### DIFF
--- a/src/building.py
+++ b/src/building.py
@@ -38,3 +38,20 @@ class Building:
     @property
     def complete(self) -> bool:
         return self.progress >= self.blueprint.build_time
+
+    # ------------------------------------------------------------------
+    def glyph_for_progress(self) -> tuple[str, Color]:
+        """Return a glyph and colour based on construction progress."""
+
+        if self.complete or self.blueprint.build_time <= 0:
+            return self.blueprint.glyph, self.blueprint.color
+
+        ratio = self.progress / self.blueprint.build_time
+        if ratio < 1 / 3:
+            glyph = "."
+        elif ratio < 2 / 3:
+            glyph = "+"
+        else:
+            glyph = self.blueprint.glyph.lower()
+
+        return glyph, self.blueprint.color

--- a/src/game.py
+++ b/src/game.py
@@ -58,7 +58,11 @@ class Villager:
             delay *= 3
         # Roads override terrain slowdown
         for b in game.buildings:
-            if b.position == self.position and b.blueprint.name == "Road" and b.complete:
+            if (
+                b.position == self.position
+                and b.blueprint.name == "Road"
+                and b.complete
+            ):
                 delay = max(1, delay // 2)
                 break
         self.cooldown = delay
@@ -216,6 +220,7 @@ class Game:
         self.buildings.append(storage)
 
         from collections import defaultdict
+
         self.tile_usage: Dict[Tuple[int, int], int] = defaultdict(int)
 
         self.renderer = Renderer()
@@ -728,6 +733,15 @@ class Game:
             build_lines = [f"{name}: {cnt}" for name, cnt in counts.items()]
             self.renderer.render_overlay(build_lines, start_y=overlay_start)
             overlay_start += len(build_lines)
+
+            progress_lines = []
+            for b in self.build_queue:
+                if b.blueprint.build_time > 0:
+                    pct = int(100 * b.progress / b.blueprint.build_time)
+                    progress_lines.append(f"{b.blueprint.name} {pct}%")
+            if progress_lines:
+                self.renderer.render_overlay(progress_lines, start_y=overlay_start)
+                overlay_start += len(progress_lines)
 
         if self.show_actions:
             lines = [f"Villager {v.id}: {v.state}" for v in self.entities]

--- a/src/renderer.py
+++ b/src/renderer.py
@@ -167,13 +167,18 @@ class Renderer:
 
         # Overlay buildings
         for b in buildings:
+            render_fn = getattr(b, "glyph_for_progress", None)
             for bx, by in getattr(
                 b, "cells", lambda: [(b.position[0], b.position[1])]
             )():
                 sx, sy = camera.world_to_screen(bx, by)
                 if 0 <= sy < len(glyph_grid) and 0 <= sx < len(glyph_grid[0]):
-                    glyph_grid[sy][sx] = b.blueprint.glyph
-                    color_grid[sy][sx] = b.blueprint.color
+                    if callable(render_fn):
+                        glyph, color = render_fn()
+                    else:
+                        glyph, color = b.blueprint.glyph, b.blueprint.color
+                    glyph_grid[sy][sx] = glyph
+                    color_grid[sy][sx] = color
 
         # Overlay villager paths first so the villager glyphs appear on top
         for vill in villagers:

--- a/tests/test_building_progress.py
+++ b/tests/test_building_progress.py
@@ -1,0 +1,59 @@
+import builtins
+from src.building import Building, BuildingBlueprint
+from src.constants import Color
+from src.renderer import Renderer
+from src.camera import Camera
+from src.map import GameMap
+
+
+def test_glyph_for_progress():
+    bp = BuildingBlueprint(
+        name="Test",
+        build_time=10,
+        footprint=[(0, 0)],
+        glyph="X",
+        color=Color.BUILDING,
+    )
+    b = Building(bp, (0, 0))
+    assert b.glyph_for_progress()[0] == "."
+    b.progress = 5
+    assert b.glyph_for_progress()[0] == "+"
+    b.progress = 9
+    assert b.glyph_for_progress()[0] == "x"
+    b.progress = 10
+    assert b.glyph_for_progress()[0] == "X"
+
+
+def test_renderer_uses_progress(monkeypatch):
+    gmap = GameMap(seed=1)
+    renderer = Renderer()
+    camera = Camera()
+    camera.set_zoom_level(0)
+    camera.x = 0
+    camera.y = 0
+    bp = BuildingBlueprint(
+        name="Test",
+        build_time=5,
+        footprint=[(0, 0)],
+        glyph="B",
+        color=Color.BUILDING,
+    )
+    building = Building(bp, (0, 0))
+
+    def fake_glyph_for_progress():
+        return "Z", Color.UI
+
+    building.glyph_for_progress = fake_glyph_for_progress
+
+    captured = {}
+
+    def fake_draw(g, c):
+        captured["glyphs"] = g
+        captured["colors"] = c
+
+    monkeypatch.setattr(renderer, "draw_grid", fake_draw)
+
+    renderer.render_game(gmap, camera, [], [building], detailed=False)
+
+    assert captured["glyphs"][0][0] == "Z"
+    assert captured["colors"][0][0] == Color.UI


### PR DESCRIPTION
## Summary
- let `Building` choose a glyph based on construction progress
- render buildings using this glyph and color
- display build queue progress in overlay
- test building glyph transitions and renderer usage

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q` *(fails: command not found)*