### PR TITLE
Fix missing colors by adding blessed

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ python3 -m venv .venv
 $ source .venv/bin/activate            # Windows: .venv\Scripts\activate
 
 # Install dependencies
-$ pip install -r requirements.txt
+$ pip install -r requirements.txt  # includes blessed for colour support
 
 # Run the game
 $ python3 -m src.main [--seed 42] [--show-fps] [-v]

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ sniffio==1.3.1
 starlette==0.27.0
 typing_extensions==4.13.2
 uvicorn==0.27.0.post1
+blessed==1.20.0


### PR DESCRIPTION
## Notes
- `pytest` was unavailable in the execution environment so tests could not run.

## Summary
- add `blessed` to `requirements.txt`
- mention blessed in README instructions
