### PR TITLE
Fix stuck villager on seed 46

### DIFF
--- a/src/pathfinding.py
+++ b/src/pathfinding.py
@@ -155,12 +155,13 @@ def find_nearest_resource(
 
         tile = gmap.get_tile(*current)
         if tile.type is resource_type and tile.resource_amount > 0:
+            found = current
             path: List[Tuple[int, int]] = [current]
             while current in came_from:
                 current = came_from[current]
                 path.append(current)
             path.reverse()
-            return current, path
+            return found, path
 
         for n in _neighbors(current, gmap):
             if not _is_passable(n, gmap, buildings):


### PR DESCRIPTION
## Summary
- pathfinding: return the correct target tile from `find_nearest_resource`

The villager could get stuck because the resource search returned the
starting position instead of the resource tile. This caused the villager
not to gather after reaching the resource.

## Testing
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement)*