### PR TITLE
Reserve bottom rows for UI panel

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -16,8 +16,11 @@ class TileType(Enum):
 
 # Camera defaults
 VIEWPORT_WIDTH = 80
-# Reserve one row for a status panel
-VIEWPORT_HEIGHT = 23
+# Height of the UI panel at the bottom of the screen
+UI_PANEL_HEIGHT = 10
+# Height of the game viewport (excluding UI panel)
+VIEWPORT_HEIGHT = 24 - UI_PANEL_HEIGHT
+# Y coordinate where the status line is rendered
 STATUS_PANEL_Y = VIEWPORT_HEIGHT
 # Discrete zoom levels: 1 cell per tile, 2 cells per tile, etc.
 ZOOM_LEVELS = [1, 2, 4]

--- a/src/game.py
+++ b/src/game.py
@@ -757,7 +757,7 @@ class Game:
         if self.show_fps:
             status += f" FPS:{self.current_fps:.1f} ({self.last_tick_ms:.1f}ms)"
         self.renderer.render_status(status)
-        overlay_start = 0
+        overlay_start = STATUS_PANEL_Y + 1
         if self.show_help:
             lines = [
                 "Controls:",
@@ -772,8 +772,8 @@ class Game:
                 "1-9 - set zoom",
                 "A - toggle actions",
             ]
-            self.renderer.render_help(lines)
-            overlay_start = len(lines)
+            self.renderer.render_help(lines, start_y=overlay_start)
+            overlay_start += len(lines)
 
         if self.show_buildings:
             counts: Dict[str, int] = defaultdict(int)
@@ -794,5 +794,4 @@ class Game:
 
         if self.show_actions:
             lines = [f"Villager {v.id}: {v.state}" for v in self.entities]
-            start_y = max(0, STATUS_PANEL_Y - len(lines))
-            self.renderer.render_overlay(lines, start_y=start_y)
+            self.renderer.render_overlay(lines, start_y=overlay_start)

--- a/src/renderer.py
+++ b/src/renderer.py
@@ -250,13 +250,14 @@ class Renderer:
             sys.stdout.write(self.term.move_xy(0, STATUS_PANEL_Y) + line)
             sys.stdout.flush()
 
-    def render_help(self, lines: list[str]) -> None:
-        """Overlay help text starting at the top-left."""
+    def render_help(self, lines: list[str], start_y: int = 0) -> None:
+        """Render help text starting at ``start_y``."""
         for idx, line in enumerate(lines):
+            y = start_y + idx
             if self.use_curses:
-                self.term.addstr(idx, 0, line)
+                self.term.addstr(y, 0, line)
             else:
-                sys.stdout.write(self.term.move_xy(0, idx) + line)
+                sys.stdout.write(self.term.move_xy(0, y) + line)
         if self.use_curses:
             self.term.refresh()
         else:


### PR DESCRIPTION
## Summary
- add `UI_PANEL_HEIGHT` constant and shrink viewport accordingly
- allow renderer to render help text starting from a provided y offset
- draw help, building, and action info in the reserved panel

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*