### PR TITLE
Add personality and mood system to villagers

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -61,3 +61,20 @@ class Style(Enum):
     NORMAL = auto()
     BOLD = auto()
     UNDERLINE = auto()
+
+
+class Personality(Enum):
+    """Villager personality traits."""
+
+    BRAVE = auto()
+    LAZY = auto()
+    INDUSTRIOUS = auto()
+    SOCIAL = auto()
+
+
+class Mood(Enum):
+    """Villager mood levels."""
+
+    HAPPY = auto()
+    NEUTRAL = auto()
+    SAD = auto()

--- a/src/game.py
+++ b/src/game.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import time
+import random
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple, Optional
@@ -15,6 +16,8 @@ from .constants import (
     MAX_STORAGE,
     SEARCH_LIMIT,
     STATUS_PANEL_Y,
+    Personality,
+    Mood,
 )
 from .pathfinding import find_nearest_resource, find_path
 from .building import BuildingBlueprint, Building
@@ -39,6 +42,10 @@ class Villager:
     target_building: Optional[Building] = None
     target_storage: Optional[Tuple[int, int]] = None
     cooldown: int = 0
+    personality: Personality = field(
+        default_factory=lambda: random.choice(list(Personality))
+    )
+    mood: Mood = Mood.NEUTRAL
 
     # ---------------------------------------------------------------
     def is_full(self) -> bool:
@@ -52,6 +59,31 @@ class Villager:
                 if abs(bx - self.position[0]) <= 5 and abs(by - self.position[1]) <= 5:
                     return max(1, delay // 2)
         return delay
+
+    def _personality_delay_factor(self) -> float:
+        if self.personality is Personality.LAZY:
+            return 1.2
+        if self.personality is Personality.INDUSTRIOUS:
+            return 0.8
+        return 1.0
+
+    def _mood_delay_factor(self) -> float:
+        if self.mood is Mood.HAPPY:
+            return 0.9
+        if self.mood is Mood.SAD:
+            return 1.1
+        return 1.0
+
+    def _action_delay(self, game: "Game", base_delay: int) -> int:
+        delay = self._apply_tool_bonus(game, base_delay)
+        delay = int(delay * self._personality_delay_factor() * self._mood_delay_factor())
+        return max(1, delay)
+
+    def adjust_mood(self, delta: int) -> None:
+        levels = [Mood.SAD, Mood.NEUTRAL, Mood.HAPPY]
+        idx = levels.index(self.mood)
+        idx = max(0, min(len(levels) - 1, idx + delta))
+        self.mood = levels[idx]
 
     def _move_step(self, game: "Game") -> bool:
         """Move one step along the current path and apply terrain slowdown."""
@@ -74,8 +106,7 @@ class Villager:
             ):
                 delay = max(1, delay // 2)
                 break
-        delay = self._apply_tool_bonus(game, delay)
-        self.cooldown = delay
+        self.cooldown = self._action_delay(game, delay)
         return True
 
     def thought(self, game: "Game") -> str:
@@ -114,12 +145,20 @@ class Villager:
 
     def update(self, game: "Game") -> None:
         """Finite state machine handling villager behaviour."""
+        if self.personality is Personality.SOCIAL:
+            if any(
+                v is not self and abs(v.x - self.x) <= 1 and abs(v.y - self.y) <= 1
+                for v in game.entities
+            ):
+                self.adjust_mood(1)
+
         if self.cooldown > 0:
             self.cooldown -= 1
             return
         if self.state == "idle":
             job = game.dispatch_job()
             if not job:
+                self.adjust_mood(-1)
                 return
             if job.type == "gather":
                 resource_type = (
@@ -171,7 +210,8 @@ class Villager:
                     self.inventory["stone"] += gained
                 else:
                     self.inventory["wood"] += gained
-                self.cooldown = self._apply_tool_bonus(game, VILLAGER_ACTION_DELAY)
+                self.adjust_mood(1)
+                self.cooldown = self._action_delay(game, VILLAGER_ACTION_DELAY)
                 if self.is_full() or tile.resource_amount == 0:
                     self.state = "deliver"
                     self.target_path = []
@@ -194,7 +234,8 @@ class Villager:
                     if self.inventory.get(res, 0) > 0:
                         game.adjust_storage(res, self.inventory.get(res, 0))
                         self.inventory[res] = 0
-                self.cooldown = self._apply_tool_bonus(game, VILLAGER_ACTION_DELAY)
+                self.adjust_mood(1)
+                self.cooldown = self._action_delay(game, VILLAGER_ACTION_DELAY)
                 self.state = "idle"
 
         if self.state == "build":
@@ -202,7 +243,8 @@ class Villager:
                 return
             if self.target_building and self.position == self.target_building.position:
                 self.target_building.progress += 1
-                self.cooldown = self._apply_tool_bonus(game, VILLAGER_ACTION_DELAY)
+                self.adjust_mood(1)
+                self.cooldown = self._action_delay(game, VILLAGER_ACTION_DELAY)
                 if self.target_building.complete:
                     self.target_building.passable = False
                     if self.target_building in game.build_queue:

--- a/src/renderer.py
+++ b/src/renderer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 from typing import TYPE_CHECKING
 
-from .constants import Color, TileType, STATUS_PANEL_Y
+from .constants import Color, TileType, STATUS_PANEL_Y, Mood
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints only
     from .map import GameMap
@@ -231,6 +231,14 @@ class Renderer:
             if 0 <= sy < len(glyph_grid) and 0 <= sx < len(glyph_grid[0]):
                 glyph_grid[sy][sx] = "@"
                 color_grid[sy][sx] = Color.UI
+                mood_char = {
+                    Mood.HAPPY: "^",
+                    Mood.NEUTRAL: "~",
+                    Mood.SAD: "v",
+                }.get(vill.mood, "~")
+                if sx + 1 < len(glyph_grid[0]):
+                    glyph_grid[sy][sx + 1] = mood_char
+                    color_grid[sy][sx + 1] = Color.UI
 
         self.draw_grid(glyph_grid, color_grid)
 

--- a/tests/test_personality.py
+++ b/tests/test_personality.py
@@ -1,0 +1,9 @@
+from src.game import Game
+from src.constants import Personality, Mood
+
+
+def test_villager_has_personality_and_mood():
+    game = Game(seed=42)
+    vill = game.entities[0]
+    assert vill.personality in list(Personality)
+    assert vill.mood is Mood.NEUTRAL


### PR DESCRIPTION
## Summary
- define `Personality` and `Mood` enums
- give villagers a personality and mood
- adjust villager cooldowns based on mood and personality
- change behaviour in update to modify mood
- render mood indicators next to villagers
- add basic test for personality and mood presence

## Testing
- `pytest -q` *(fails: command not found)*