### PR TITLE
Villagers remain adjacent while building

### DIFF
--- a/src/pathfinding.py
+++ b/src/pathfinding.py
@@ -249,3 +249,36 @@ def find_path_hierarchical(
         path.extend(final_segment)
 
     return path
+
+
+def find_path_to_building_adjacent(
+    start: Tuple[int, int],
+    building: object,
+    gmap: GameMap,
+    buildings: Iterable[object] | None = None,
+) -> List[Tuple[int, int]]:
+    """Return a path to a passable tile adjacent to ``building``."""
+
+    if buildings is None:
+        buildings = []
+
+    if hasattr(building, "cells"):
+        cells = building.cells()
+    else:
+        cells = [getattr(building, "position", (0, 0))]
+
+    candidates: Set[Tuple[int, int]] = set()
+    for bx, by in cells:
+        for dx, dy in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
+            cx, cy = bx + dx, by + dy
+            if 0 <= cx < gmap.width and 0 <= cy < gmap.height:
+                if _is_passable((cx, cy), gmap, buildings):
+                    candidates.add((cx, cy))
+
+    best: List[Tuple[int, int]] = []
+    for cand in candidates:
+        path = find_path(start, cand, gmap, buildings)
+        if path and (not best or len(path) < len(best)):
+            best = path
+
+    return best

--- a/tests/test_building_stationary.py
+++ b/tests/test_building_stationary.py
@@ -1,0 +1,27 @@
+from src.game import Game, Job
+from src.building import Building
+
+
+def test_villager_stays_adjacent_while_building():
+    game = Game(seed=42)
+    vill = game.entities[0]
+    bp = game.blueprints["House"]
+    pos = (game.townhall_pos[0] + 2, game.townhall_pos[1])
+    building = Building(bp, pos)
+    game.buildings.append(building)
+    game.build_queue.append(building)
+    game.jobs.append(Job("build", building))
+
+    building_positions = []
+    started = False
+    for _ in range(bp.build_time + 5):
+        vill.update(game)
+        if building.progress > 0:
+            started = True
+        if started:
+            building_positions.append(vill.position)
+        if building.complete:
+            break
+    assert building.complete
+    for p in building_positions:
+        assert abs(p[0] - pos[0]) + abs(p[1] - pos[1]) == 1


### PR DESCRIPTION
## Summary
- make pathfinding helper for moving next to a building
- update villager FSM so villagers walk next to a build site and remain there until the structure is completed
- show building activity when adjacent to a building
- add regression test for staying adjacent during construction

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*