### PR TITLE
Implement day-night cycle with villager sleep

### DIFF
--- a/src/building.py
+++ b/src/building.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Tuple
 
 from .constants import Color
@@ -27,6 +27,7 @@ class Building:
     position: Tuple[int, int]
     progress: int = 0
     passable: bool = True
+    residents: List[int] = field(default_factory=list)
 
     def cells(self) -> List[Tuple[int, int]]:
         """World coordinates occupied by this building."""

--- a/src/renderer.py
+++ b/src/renderer.py
@@ -143,6 +143,8 @@ class Renderer:
         villagers: list["Villager"],
         buildings: list[object] | None = None,
         detailed: bool = False,
+        *,
+        is_night: bool = False,
     ) -> None:
         """Render the visible portion of the map with villagers and buildings."""
 
@@ -159,6 +161,8 @@ class Renderer:
                 wy = camera.y + ty
                 tile = gmap.get_tile(wx, wy)
                 glyph, color = self._tile_to_render(tile.type, detailed)
+                if is_night:
+                    glyph = glyph.lower()
                 glyph_row.extend([glyph] * camera.zoom)
                 color_row.extend([color] * camera.zoom)
             for _ in range(camera.zoom):
@@ -178,10 +182,7 @@ class Renderer:
                     else:
                         glyph, color = b.blueprint.glyph, b.blueprint.color
 
-                    if (
-                        b.blueprint.name == "Road"
-                        and getattr(b, "complete", False)
-                    ):
+                    if b.blueprint.name == "Road" and getattr(b, "complete", False):
                         n = any(
                             nb.position == (bx, by - 1)
                             and nb.blueprint.name == "Road"
@@ -229,7 +230,7 @@ class Renderer:
         for vill in villagers:
             sx, sy = camera.world_to_screen(vill.x, vill.y)
             if 0 <= sy < len(glyph_grid) and 0 <= sx < len(glyph_grid[0]):
-                glyph_grid[sy][sx] = "@"
+                glyph_grid[sy][sx] = "z" if getattr(vill, "asleep", False) else "@"
                 color_grid[sy][sx] = Color.UI
                 mood_char = {
                     Mood.HAPPY: "^",

--- a/src/villager.py
+++ b/src/villager.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints only
+    from .game import Game
+
+from .building import Building
+from .constants import (
+    CARRY_CAPACITY,
+    Mood,
+    Personality,
+    TileType,
+    VILLAGER_ACTION_DELAY,
+)
+from .pathfinding import find_nearest_resource, find_path
+
+
+@dataclass
+class Villager:
+    """Autonomous villager entity with a simple behaviour tree."""
+
+    id: int
+    position: Tuple[int, int]
+    state: str = "idle"
+    inventory: Dict[str, int] = field(default_factory=lambda: {"wood": 0, "stone": 0})
+    carrying_capacity: int = CARRY_CAPACITY
+    target_path: List[Tuple[int, int]] = field(default_factory=list)
+    target_resource: Optional[Tuple[int, int]] = None
+    resource_type: Optional[TileType] = None
+    target_building: Optional[Building] = None
+    target_storage: Optional[Tuple[int, int]] = None
+    cooldown: int = 0
+    personality: Personality = field(
+        default_factory=lambda: random.choice(list(Personality))
+    )
+    mood: Mood = Mood.NEUTRAL
+    home: Optional[Tuple[int, int]] = None
+    asleep: bool = False
+
+    # ---------------------------------------------------------------
+    def is_full(self) -> bool:
+        return sum(self.inventory.values()) >= self.carrying_capacity
+
+    def _apply_tool_bonus(self, game: "Game", delay: int) -> int:
+        for b in game.buildings:
+            if b.blueprint.name == "Blacksmith" and b.complete:
+                bx, by = b.position
+                if abs(bx - self.position[0]) <= 5 and abs(by - self.position[1]) <= 5:
+                    return max(1, delay // 2)
+        return delay
+
+    def _personality_delay_factor(self) -> float:
+        if self.personality is Personality.LAZY:
+            return 1.2
+        if self.personality is Personality.INDUSTRIOUS:
+            return 0.8
+        return 1.0
+
+    def _mood_delay_factor(self) -> float:
+        if self.mood is Mood.HAPPY:
+            return 0.9
+        if self.mood is Mood.SAD:
+            return 1.1
+        return 1.0
+
+    def _action_delay(self, game: "Game", base_delay: int) -> int:
+        delay = self._apply_tool_bonus(game, base_delay)
+        delay = int(
+            delay * self._personality_delay_factor() * self._mood_delay_factor()
+        )
+        return max(1, delay)
+
+    def adjust_mood(self, delta: int) -> None:
+        levels = [Mood.SAD, Mood.NEUTRAL, Mood.HAPPY]
+        idx = levels.index(self.mood)
+        idx = max(0, min(len(levels) - 1, idx + delta))
+        self.mood = levels[idx]
+
+    def _move_step(self, game: "Game") -> bool:
+        if not self.target_path:
+            return False
+        self.position = self.target_path.pop(0)
+        game.record_tile_usage(self.position)
+        tile = game.map.get_tile(*self.position)
+        delay = VILLAGER_ACTION_DELAY
+        if tile.type is TileType.TREE:
+            delay *= 2
+        elif tile.type is TileType.ROCK:
+            delay *= 3
+        for b in game.buildings:
+            if (
+                b.position == self.position
+                and b.blueprint.name == "Road"
+                and b.complete
+            ):
+                delay = max(1, delay // 2)
+                break
+        self.cooldown = self._action_delay(game, delay)
+        return True
+
+    def thought(self, game: "Game") -> str:
+        if self.cooldown > 0:
+            return "Waiting..."
+        if self.state == "idle":
+            return "Idle"
+        if self.state == "gather":
+            if self.target_resource:
+                if self.position == self.target_resource:
+                    return f"Gathering {self.resource_type.name.lower()}"
+                if self.target_path:
+                    return f"Heading to {self.resource_type.name.lower()} at {self.target_resource}"
+                return "Stuck: no path to resource"
+            return "Searching for resource"
+        if self.state == "deliver":
+            if self.position in game.storage_positions:
+                return "Delivering"
+            if self.target_path:
+                return f"Returning to storage at {self.target_storage}"
+            return "Stuck: no path to storage"
+        if self.state == "build":
+            if self.target_building:
+                if self.position == self.target_building.position:
+                    return f"Building {self.target_building.blueprint.name}"
+                if self.target_path:
+                    return f"Heading to build {self.target_building.blueprint.name}"
+                return "Stuck: no path to site"
+            return "Searching for build"
+        if self.state == "sleeping":
+            return "Sleeping"
+        return self.state
+
+    def update(self, game: "Game") -> None:
+        if game.world.is_night:
+            self.target_resource = None
+            self.target_building = None
+            if self.home and self.position != self.home:
+                if not self.target_path:
+                    path = find_path(self.position, self.home, game.map, game.buildings)
+                    self.target_path = path[1:]
+                self._move_step(game)
+            else:
+                self.state = "sleeping"
+                self.asleep = True
+                self.target_path = []
+            return
+        if self.asleep:
+            self.asleep = False
+            self.state = "idle"
+        if self.personality is Personality.SOCIAL:
+            if any(
+                v is not self and abs(v.x - self.x) <= 1 and abs(v.y - self.y) <= 1
+                for v in game.entities
+            ):
+                self.adjust_mood(1)
+        if self.cooldown > 0:
+            self.cooldown -= 1
+            return
+        if self.state == "idle":
+            job = game.dispatch_job()
+            if not job:
+                self.adjust_mood(-1)
+                return
+            if job.type == "gather":
+                resource_type = (
+                    job.payload if isinstance(job.payload, TileType) else TileType.TREE
+                )
+                pos, path = find_nearest_resource(
+                    self.position,
+                    resource_type,
+                    game.map,
+                    game.buildings,
+                    search_limit=game.get_search_limit(),
+                )
+                if pos is None:
+                    return
+                self.resource_type = resource_type
+                self.target_resource = pos
+                self.target_path = path[1:]
+                self.state = "gather"
+                return
+            if job.type == "build":
+                self.target_building = job.payload
+                path = find_path(
+                    self.position,
+                    self.target_building.position,
+                    game.map,
+                    game.buildings,
+                )
+                self.target_path = path[1:]
+                self.state = "build"
+                return
+        if self.state == "gather":
+            if self._move_step(game):
+                return
+            if self.target_resource and self.position == self.target_resource:
+                tile = game.map.get_tile(*self.position)
+                rate = 1
+                for b in game.buildings:
+                    if b.blueprint.name == "Quarry" and b.complete:
+                        bx, by = b.position
+                        if (
+                            abs(bx - self.position[0]) <= 5
+                            and abs(by - self.position[1]) <= 5
+                        ):
+                            rate = 2
+                            break
+                gained = tile.extract(rate)
+                if self.resource_type is TileType.ROCK:
+                    self.inventory["stone"] += gained
+                else:
+                    self.inventory["wood"] += gained
+                self.adjust_mood(1)
+                self.cooldown = self._action_delay(game, VILLAGER_ACTION_DELAY)
+                if self.is_full() or tile.resource_amount == 0:
+                    self.state = "deliver"
+                    self.target_path = []
+            return
+        if self.state == "deliver":
+            if not self.target_path:
+                self.target_storage = game.nearest_storage(self.position)
+                path = find_path(
+                    self.position, self.target_storage, game.map, game.buildings
+                )
+                self.target_path = path[1:]
+            if self._move_step(game):
+                return
+            if self.position in game.storage_positions:
+                for res in ("wood", "stone"):
+                    if self.inventory.get(res, 0) > 0:
+                        game.adjust_storage(res, self.inventory.get(res, 0))
+                        self.inventory[res] = 0
+                self.adjust_mood(1)
+                self.cooldown = self._action_delay(game, VILLAGER_ACTION_DELAY)
+                self.state = "idle"
+        if self.state == "build":
+            if self._move_step(game):
+                return
+            if self.target_building and self.position == self.target_building.position:
+                self.target_building.progress += 1
+                self.adjust_mood(1)
+                self.cooldown = self._action_delay(game, VILLAGER_ACTION_DELAY)
+                if self.target_building.complete:
+                    self.target_building.passable = False
+                    if self.target_building in game.build_queue:
+                        game.build_queue.remove(self.target_building)
+                    if self.target_building.blueprint.name == "House":
+                        game.schedule_spawn(self.target_building.position)
+                else:
+                    from .game import Job
+
+                    game.jobs.append(Job("build", self.target_building))
+                self.state = "idle"
+
+    @property
+    def x(self) -> int:
+        return self.position[0]
+
+    @property
+    def y(self) -> int:
+        return self.position[1]

--- a/src/world.py
+++ b/src/world.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+
+class World:
+    """Simple container for global time and day/night cycle."""
+
+    def __init__(self, tick_rate: int, day_length: int | None = None) -> None:
+        self.tick_rate = tick_rate
+        self.day_length = day_length or tick_rate * 30
+        self.tick_count = 0
+
+    def tick(self) -> None:
+        """Advance world time by one tick."""
+        self.tick_count += 1
+
+    @property
+    def is_night(self) -> bool:
+        cycle_pos = self.tick_count % self.day_length
+        return cycle_pos >= self.day_length // 2

--- a/tests/test_day_night.py
+++ b/tests/test_day_night.py
@@ -1,0 +1,27 @@
+from src.world import World
+from src.game import Game
+from src.building import Building
+
+
+def test_world_day_night_toggle():
+    world = World(tick_rate=10, day_length=20)
+    assert not world.is_night
+    for _ in range(10):
+        world.tick()
+    assert world.is_night
+
+
+def test_villager_sleeps_at_night():
+    game = Game(seed=1)
+    vill = game.entities[0]
+    bp = game.blueprints["House"]
+    house = Building(bp, vill.position)
+    house.progress = bp.build_time
+    house.passable = True
+    game.buildings.append(house)
+    house.residents.append(vill.id)
+    vill.home = house.position
+    game.world.tick_count = game.world.day_length // 2 + 1
+    vill.update(game)
+    assert vill.asleep
+    assert vill.state == "sleeping"

--- a/tests/test_pathfinding.py
+++ b/tests/test_pathfinding.py
@@ -32,10 +32,9 @@ def test_find_nearest_resource_prefers_roads():
     gmap.get_tile(0, 3).type = TileType.ROCK
     gmap.get_tile(0, 3).resource_amount = 100
 
-    pos, _ = find_nearest_resource(
-        (0, 0), TileType.ROCK, gmap, roads, search_limit=20
-    )
+    pos, _ = find_nearest_resource((0, 0), TileType.ROCK, gmap, roads, search_limit=20)
     assert pos == (0, 3)
+
 
 def test_hierarchical_path_returns_to_goal():
     gmap = GameMap(seed=2)
@@ -47,4 +46,3 @@ def test_hierarchical_path_returns_to_goal():
     for a, b in zip(path, path[1:]):
         dx = abs(a[0] - b[0]) + abs(a[1] - b[1])
         assert dx == 1
-


### PR DESCRIPTION
## Summary
- create `World` for day/night tracking
- extract villager logic to new module and add sleep/home behaviour
- track villager homes via building residents
- render sleeping villagers and darken tiles at night
- add tests for day/night cycle

## Testing
- `ruff check .`
- `black . --check`
- `pytest -q` *(fails: pytest not installed)*