### PR TITLE
Refactor renderer with lighting filters

### DIFF
--- a/src/filters.py
+++ b/src/filters.py
@@ -1,0 +1,63 @@
+# Lighting and colour filter pipeline
+from __future__ import annotations
+
+from typing import Callable, Iterable, Tuple
+import math
+
+from .constants import TileType, ZoneType
+from .tile import Tile
+
+ColorRGB = Tuple[int, int, int]
+Filter = Callable[[ColorRGB, Tile, float], ColorRGB]
+
+# Base colours for tiles ----------------------------------------------
+BASE_TILE_COLOURS: dict[TileType, ColorRGB] = {
+    TileType.GRASS: (34, 139, 34),
+    TileType.TREE: (0, 100, 0),
+    TileType.ROCK: (128, 128, 128),
+    TileType.WATER: (0, 0, 255),
+}
+
+# Zone tint colours
+ZONE_TINTS: dict[ZoneType, ColorRGB] = {
+    ZoneType.HOUSING: (50, 200, 50),
+    ZoneType.WORK: (200, 200, 50),
+    ZoneType.MARKET: (50, 50, 200),
+}
+
+
+# Pipeline -------------------------------------------------------------
+
+def apply_lighting(tile: Tile, day_fraction: float, filters: Iterable[Filter]) -> ColorRGB:
+    """Return final colour for ``tile`` after applying ``filters``."""
+    color = BASE_TILE_COLOURS.get(tile.type, (255, 255, 255))
+    for f in filters:
+        color = f(color, tile, day_fraction)
+    return color
+
+
+# Built-in filters ----------------------------------------------------
+
+def day_night_filter(color: ColorRGB, tile: Tile, day_fraction: float) -> ColorRGB:
+    """Darken or lighten ``color`` based on ``day_fraction``.
+
+    ``day_fraction`` should be in ``[0,1]`` where ``0`` is midnight and ``0.5``
+    is noon.
+    """
+    brightness = 0.3 + 0.7 * math.sin(math.pi * day_fraction)
+    r, g, b = color
+    return (int(r * brightness), int(g * brightness), int(b * brightness))
+
+
+def zone_filter(color: ColorRGB, tile: Tile, day_fraction: float) -> ColorRGB:
+    """Tint tiles based on their zone."""
+    if tile.zone is None:
+        return color
+    tint = ZONE_TINTS.get(tile.zone)
+    if tint is None:
+        return color
+    blend = 0.5
+    r = int(color[0] * (1 - blend) + tint[0] * blend)
+    g = int(color[1] * (1 - blend) + tint[1] * blend)
+    b = int(color[2] * (1 - blend) + tint[2] * blend)
+    return (r, g, b)

--- a/src/game.py
+++ b/src/game.py
@@ -758,6 +758,7 @@ class Game:
             self.buildings,
             detailed=detailed,
             is_night=self.world.is_night,
+            day_fraction=self.world.day_fraction,
         )
         status = (
             f"Tick:{self.tick_count} "

--- a/src/world.py
+++ b/src/world.py
@@ -26,3 +26,8 @@ class World:
         hours = int(day_fraction * 24)
         minutes = int((day_fraction * 24 - hours) * 60)
         return f"{hours:02d}:{minutes:02d}"
+
+    @property
+    def day_fraction(self) -> float:
+        """Current time of day as a value in ``[0, 1]``."""
+        return (self.tick_count % self.day_length) / self.day_length

--- a/tests/test_lighting.py
+++ b/tests/test_lighting.py
@@ -1,0 +1,22 @@
+from src.filters import apply_lighting, day_night_filter, zone_filter, ColorRGB, BASE_TILE_COLOURS
+from src.tile import Tile
+from src.constants import TileType, ZoneType
+
+
+def test_day_night_filter_darkens():
+    colour = (100, 100, 100)
+    result = day_night_filter(colour, Tile(TileType.GRASS), 0.0)
+    assert result == (30, 30, 30)
+
+
+def test_zone_filter_tints():
+    colour = (100, 100, 100)
+    tile = Tile(TileType.GRASS, zone=ZoneType.HOUSING)
+    result = zone_filter(colour, tile, 0.0)
+    assert result == (75, 150, 75)
+
+
+def test_apply_lighting_combines():
+    tile = Tile(TileType.GRASS, zone=ZoneType.HOUSING)
+    result = apply_lighting(tile, 0.5, [zone_filter, day_night_filter])
+    assert result == (42, 169, 42)


### PR DESCRIPTION
## Summary
- add lighting filter pipeline with day/night and zone filters
- integrate pipeline into renderer and game loop
- expose `World.day_fraction` helper
- test new filter behaviour

## Testing
- `python -m py_compile src/filters.py src/renderer.py src/world.py src/game.py tests/test_lighting.py`
- `python -m pip install -r requirements.txt` *(fails: No route to host)*
- `pytest -q` *(fails: command not found)*