### PR TITLE
Add villager lifecycle

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -92,3 +92,12 @@ class ZoneType(Enum):
     HOUSING = auto()
     WORK = auto()
     MARKET = auto()
+
+
+class LifeStage(Enum):
+    """Lifecycle stages for villagers."""
+
+    CHILD = auto()
+    ADULT = auto()
+    ELDER = auto()
+    RETIRED = auto()

--- a/src/world.py
+++ b/src/world.py
@@ -8,10 +8,14 @@ class World:
         self.tick_rate = tick_rate
         self.day_length = day_length or tick_rate * 30
         self.tick_count = 0
+        self.day = 0
 
     def tick(self) -> None:
         """Advance world time by one tick."""
+        prev = self.tick_count // self.day_length
         self.tick_count += 1
+        if self.tick_count // self.day_length > prev:
+            self.day += 1
 
     @property
     def is_night(self) -> bool:

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,28 @@
+from src.game import Game
+from src.building import Building
+from src.constants import LifeStage
+
+
+def test_aging_transitions():
+    game = Game(seed=1)
+    vill = game.entities[0]
+    assert vill.life_stage is LifeStage.ADULT
+    vill.age = 64
+    vill.age_one_day(game)
+    assert vill.life_stage is LifeStage.ELDER
+    vill.age = 79
+    vill.age_one_day(game)
+    assert vill.life_stage is LifeStage.RETIRED
+
+
+def test_birth_requires_food_and_housing():
+    game = Game(seed=1)
+    bp = game.blueprints["House"]
+    house = Building(bp, game.townhall_pos)
+    house.progress = bp.build_time
+    house.passable = False
+    game.buildings.append(house)
+    game.storage["food"] = 1
+    game._handle_births()
+    game._process_spawns()
+    assert any(v.life_stage is LifeStage.CHILD for v in game.entities)


### PR DESCRIPTION
## Summary
- add `LifeStage` enum and store life stage on Villager
- adjust villager action delay based on age and track aging daily
- retire villagers and provide simple mentorship bonus
- spawn children when houses have capacity and food is available
- keep a HUD event log of births and aging milestones
- test villager aging stages and birth logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q` *(fails: No module named pytest)*