### PR TITLE
Fix building behavior for villagers

### DIFF
--- a/src/villager.py
+++ b/src/villager.py
@@ -296,6 +296,8 @@ class Villager:
                     from .game import Job
 
                     game.jobs.append(Job("build", self.target_building))
+                    # Stay in build state to continue working on the same building
+                    return
                 self.state = "idle"
 
     @property


### PR DESCRIPTION
## Summary
- keep villagers in the build state until the target building is complete

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*