### PR TITLE
Fix freeze caused by heavy pathfinding

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -44,7 +44,7 @@ MAX_STORAGE = 100
 
 # Maximum nodes explored during breadth-first searches to avoid hangs on
 # extremely large maps.
-SEARCH_LIMIT = 10000
+SEARCH_LIMIT = 1000
 
 # Fixed colour for all UI elements (RGB)
 UI_COLOR_RGB = (255, 255, 255)


### PR DESCRIPTION
## Summary
- reduce path finding `SEARCH_LIMIT` to stop runaway searches on large maps

## Testing
- `pytest -q` *(fails: command not found)*