### PR TITLE
Fix freeze by assigning builders

### DIFF
--- a/src/building.py
+++ b/src/building.py
@@ -33,6 +33,7 @@ class Building:
     level: int = 1
     capacity: int = 0
     efficiency: float = 1.0
+    builder_id: int | None = None
 
     # ---------------------------------------------------------------
     def upgrade_cost(self) -> Tuple[int, int]:

--- a/src/villager.py
+++ b/src/villager.py
@@ -203,7 +203,7 @@ class Villager:
             self.cooldown -= 1
             return
         if self.state == "idle":
-            job = game.dispatch_job()
+            job = game.dispatch_job(self)
             if not job:
                 self.adjust_mood(-1)
                 return

--- a/tests/test_building_stationary.py
+++ b/tests/test_building_stationary.py
@@ -1,4 +1,4 @@
-from src.game import Game, Job
+from src.game import Game
 from src.building import Building
 
 
@@ -10,7 +10,7 @@ def test_villager_stays_adjacent_while_building():
     building = Building(bp, pos)
     game.buildings.append(building)
     game.build_queue.append(building)
-    game.jobs.append(Job("build", building))
+    game._assign_builder(building)
 
     building_positions = []
     started = False


### PR DESCRIPTION
## Notes
- pip failed to install pytest due to network restrictions, so tests couldn't be run.

## Summary
- add `builder_id` to `Building` to track assigned villager
- route new building jobs through `_assign_builder`
- let `dispatch_job` return jobs targeted to a villager
- update villager update loop and stationary building test
