### PR TITLE
Implement new town hall focus and slower tick rate

### DIFF
--- a/src/blueprints/house.py
+++ b/src/blueprints/house.py
@@ -11,4 +11,5 @@ BLUEPRINT = BuildingBlueprint(
     color=Color.BUILDING,
     wood=15,
     stone=0,
+    capacity=2,
 )

--- a/src/building.py
+++ b/src/building.py
@@ -35,6 +35,11 @@ class Building:
     efficiency: float = 1.0
     builder_id: int | None = None
 
+    def __post_init__(self) -> None:
+        """Initialise stats from the blueprint."""
+        self.capacity = self.blueprint.capacity
+        self.efficiency = self.blueprint.efficiency
+
     # ---------------------------------------------------------------
     def upgrade_cost(self) -> Tuple[int, int]:
         """Return wood and stone cost for the next upgrade."""

--- a/src/constants.py
+++ b/src/constants.py
@@ -27,8 +27,8 @@ ZOOM_LEVELS = [1, 2, 4]
 DEFAULT_ZOOM_INDEX = 0
 
 # Game tick rate (ticks per second)
-# Reduced to improve smoothness and lower CPU load
-TICK_RATE = 180
+# Lowered so the simulation runs at a calmer pace
+TICK_RATE = 60
 
 # How often to fully refresh the UI to avoid artefacts
 UI_REFRESH_INTERVAL = TICK_RATE * 5  # every 5 seconds


### PR DESCRIPTION
## Summary
- lower game tick rate to 60
- initialise building capacity from blueprint and give houses capacity 2
- use house capacity when assigning homes and handling births
- prioritise town hall upgrades via `_plan_townhall_progress`
- keep population growth through `_expand_housing`

## Testing
- `venv/bin/pytest -q`