### PR TITLE
Add villager wander fallback

### DIFF
--- a/tests/test_wander.py
+++ b/tests/test_wander.py
@@ -1,0 +1,18 @@
+import random
+
+import src.villager as villager_mod
+from src.game import Game
+
+
+def test_villager_wanders_when_search_fails(monkeypatch):
+    game = Game(seed=1)
+    vill = game.entities[0]
+    start = vill.position
+
+    monkeypatch.setattr(
+        villager_mod, "find_nearest_resource", lambda *a, **k: (None, [])
+    )
+    monkeypatch.setattr(random, "shuffle", lambda x: None)
+
+    vill.update(game)
+    assert vill.position != start


### PR DESCRIPTION
## Summary
- add wandering logic for villagers when pathfinding fails
- use wander fallback when a resource search or path computation returns nothing
- include tests for the new wandering behaviour

## Testing
- `ruff check .`
- `black -q .`
- `pytest -q` *(fails: command not found)*