### PR TITLE
Fix start location search

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -343,7 +343,8 @@ class Game:
         q = deque([origin])
         visited = {origin}
         searched = 0
-        while q and searched < SEARCH_LIMIT:
+        limit = SEARCH_LIMIT * 10
+        while q and searched < limit:
             x, y = q.popleft()
             searched += 1
             if self.map.get_tile(x, y).passable:


### PR DESCRIPTION
## Summary
- search wider for a suitable starting location with both trees and rocks

## Testing
- `ruff check src`
- `black -q src/game.py`
- `pytest -q` *(fails: command not found)*