### PR TITLE
Implement natural terrain and resource clusters

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -9,7 +9,6 @@ from typing import Dict, List, Tuple, Optional
 
 from .constants import (
     TileType,
-    ZOOM_LEVELS,
     TICK_RATE,
     UI_REFRESH_INTERVAL,
     MAX_STORAGE,
@@ -45,6 +44,8 @@ class Game:
     def __init__(self, seed: int | None = None) -> None:
         random.seed(seed)
         self.map = GameMap(seed=seed)
+        for row in self.map.terrain.preview():
+            print(row)
         self.entities: List[Villager] = []
         self.buildings: List[Building] = []
         self.build_queue: List[Building] = []
@@ -356,9 +357,9 @@ class Game:
             x, y = q.popleft()
             searched += 1
             if self.map.get_tile(x, y).passable:
-                trees = self._count_resource_nearby((x, y), TileType.TREE, radius=10)
-                rocks = self._count_resource_nearby((x, y), TileType.ROCK, radius=10)
-                if trees >= 5 and rocks >= 5:
+                trees = self._count_resource_nearby((x, y), TileType.TREE, radius=100)
+                rocks = self._count_resource_nearby((x, y), TileType.ROCK, radius=100)
+                if trees > 0 and rocks > 0:
                     return (x, y)
             for dx, dy in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
                 nx, ny = x + dx, y + dy
@@ -490,6 +491,12 @@ class Game:
         self, blueprint: BuildingBlueprint
     ) -> Optional[Tuple[int, int]]:
         """Find a quarry site near existing buildings prioritising stone density."""
+        clusters = getattr(self.map, "precomputed_clusters", {}).get(TileType.ROCK, [])
+        for cx, cy in clusters:
+            if self.is_area_free((cx, cy), blueprint):
+                if self._count_resource_nearby((cx, cy), TileType.ROCK, radius=2) > 0:
+                    return (cx, cy)
+
         from collections import deque
 
         starts = [b.position for b in self.buildings] or [self.storage_pos]
@@ -497,7 +504,7 @@ class Game:
         q = deque(starts)
         best: Tuple[int, int] | None = None
         best_score = -1
-        search_limit = 500
+        search_limit = 10000
         searched = 0
         while q and searched < search_limit:
             p = q.popleft()

--- a/src/map.py
+++ b/src/map.py
@@ -1,6 +1,7 @@
-import random
 from dataclasses import dataclass
 from typing import Dict, Tuple
+
+from .terrain import TerrainGenerator
 
 from .constants import MAP_WIDTH, MAP_HEIGHT, TileType, ZoneType
 from .tile import Tile
@@ -24,50 +25,25 @@ class GameMap:
         self.width = MAP_WIDTH
         self.height = MAP_HEIGHT
         self.seed = seed or 0
-        self._rand = random.Random(seed)
+        self.terrain = TerrainGenerator(self.width, self.height, self.seed)
+        self.precomputed_clusters = self.terrain.precomputed_clusters
         # Tiles are generated lazily and cached in this dict
         self._tiles: Dict[Tuple[int, int], Tile] = {}
         # Map of coordinates to zone type
         self._zones: Dict[Tuple[int, int], ZoneType] = {}
         # Ensure origin is always passable for deterministic tests
         self._tiles[(0, 0)] = Tile(TileType.GRASS, 0, True)
+        self._clear_start_area()
 
-    def _hash(self, x: int, y: int) -> float:
-        """Deterministic hash used for noise generation."""
-        return random.Random((x * 73856093) ^ (y * 19349663) ^ self.seed).random()
-
-    def _lerp(self, a: float, b: float, t: float) -> float:
-        return a + (b - a) * t
-
-    def _value_noise(self, x: int, y: int, scale: int = 25) -> float:
-        """Simple value noise based on deterministic hashes."""
-        x0 = x // scale
-        y0 = y // scale
-        fx = (x % scale) / scale
-        fy = (y % scale) / scale
-
-        n00 = self._hash(x0, y0)
-        n10 = self._hash(x0 + 1, y0)
-        n01 = self._hash(x0, y0 + 1)
-        n11 = self._hash(x0 + 1, y0 + 1)
-
-        nx0 = self._lerp(n00, n10, fx)
-        nx1 = self._lerp(n01, n11, fx)
-        return self._lerp(nx0, nx1, fy)
+    def _clear_start_area(self) -> None:
+        """Ensure a small patch around the origin is walkable."""
+        for x in range(3):
+            for y in range(3):
+                self._tiles[(x, y)] = Tile(TileType.GRASS, 0, True)
 
     def _generate_tile(self, x: int, y: int) -> Tile:
-        noise = self._value_noise(x, y)
-        if noise < 0.5:
-            return Tile(TileType.GRASS, resource_amount=0, passable=True)
-        if noise < 0.65:
-            decorative = self._hash(x + 1, y + 1) < 0.1
-            amt = 0 if decorative else 100
-            # Trees should be traversable so villagers can gather wood
-            return Tile(TileType.TREE, resource_amount=amt, passable=True)
-        if noise < 0.98:
-            # Allow walking onto rocks for mining
-            return Tile(TileType.ROCK, resource_amount=100, passable=True)
-        return Tile(TileType.WATER, resource_amount=0, passable=False)
+        t, amt, passable = self.terrain.tile_at(x, y)
+        return Tile(t, resource_amount=amt, passable=passable)
 
     def get_tile(self, x: int, y: int) -> Tile:
         """Return the tile at ``x,y``, generating it if necessary."""

--- a/src/terrain.py
+++ b/src/terrain.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import random
+from typing import Dict, List, Tuple
+
+from .constants import MAP_WIDTH, MAP_HEIGHT, TileType
+
+
+class TerrainGenerator:
+    """Generate biomes and resource clusters using layered noise."""
+
+    def __init__(
+        self, width: int = MAP_WIDTH, height: int = MAP_HEIGHT, seed: int = 0
+    ) -> None:
+        self.width = width
+        self.height = height
+        self.seed = seed
+        self._rand = random.Random(seed)
+        self.precomputed_clusters: Dict[TileType, List[Tuple[int, int]]] = {
+            TileType.TREE: [],
+            TileType.ROCK: [],
+        }
+        # Generate a few random cluster centres for resources
+        self._init_clusters()
+
+    # --- Noise helpers -------------------------------------------------
+    def _hash(self, x: int, y: int) -> float:
+        return random.Random((x * 92837111) ^ (y * 689287499) ^ self.seed).random()
+
+    def _lerp(self, a: float, b: float, t: float) -> float:
+        return a + (b - a) * t
+
+    def _value_noise(self, x: int, y: int, scale: int = 50) -> float:
+        x0 = x // scale
+        y0 = y // scale
+        fx = (x % scale) / scale
+        fy = (y % scale) / scale
+        n00 = self._hash(x0, y0)
+        n10 = self._hash(x0 + 1, y0)
+        n01 = self._hash(x0, y0 + 1)
+        n11 = self._hash(x0 + 1, y0 + 1)
+        nx0 = self._lerp(n00, n10, fx)
+        nx1 = self._lerp(n01, n11, fx)
+        return self._lerp(nx0, nx1, fy)
+
+    # --- Public API ----------------------------------------------------
+    def tile_at(self, x: int, y: int) -> Tuple[TileType, int, bool]:
+        """Return terrain at ``x,y``."""
+        elevation = self._value_noise(x, y, scale=100)
+        moisture = self._value_noise(x + 1000, y + 1000, scale=100)
+        if elevation < 0.3:
+            return TileType.WATER, 0, False
+        if elevation > 0.8:
+            return TileType.ROCK, 100, True
+        if moisture > 0.6:
+            amt = 100 if self._hash(x + 1, y + 1) > 0.2 else 0
+            return TileType.TREE, amt, True
+        return TileType.GRASS, 0, True
+
+    def _init_clusters(self) -> None:
+        """Populate ``precomputed_clusters`` with random centres."""
+        count = 50
+        for _ in range(count):
+            x = self._rand.randint(0, self.width - 1)
+            y = self._rand.randint(0, self.height - 1)
+            t, amt, _ = self.tile_at(x, y)
+            if t in (TileType.TREE, TileType.ROCK) and amt > 0:
+                self.precomputed_clusters[t].append((x, y))
+
+    def preview(self, scale: int = 1000) -> List[str]:
+        """Return a coarse preview of the map."""
+        rows: List[str] = []
+        for y in range(0, self.height, scale):
+            row = []
+            for x in range(0, self.width, scale):
+                t, _, _ = self.tile_at(x, y)
+                if t is TileType.WATER:
+                    row.append("~")
+                elif t is TileType.ROCK:
+                    row.append("^")
+                elif t is TileType.TREE:
+                    row.append("T")
+                else:
+                    row.append(".")
+            rows.append("".join(row))
+        return rows

--- a/tests/test_building_passable.py
+++ b/tests/test_building_passable.py
@@ -18,4 +18,3 @@ def test_road_remains_passable_after_built():
     vill.update(game)
     assert b.complete
     assert b.passable is True
-


### PR DESCRIPTION
## Summary
- add a `TerrainGenerator` for layered noise and resource cluster centres
- use the generator inside `GameMap`
- supply precomputed clusters to pathfinding
- loosen starting tile search and add quarry helper fallback
- show a quick world preview on startup

## Testing
- `ruff check .`
- `black --check src tests`
- `./venv/bin/pytest -q`