### PR TITLE
Add nighttime slowdown instead of sleep

### DIFF
--- a/src/world.py
+++ b/src/world.py
@@ -21,9 +21,9 @@ class World:
 
     @property
     def is_night(self) -> bool:
-        """Return True if time is between 00:00 and 03:00."""
+        """Return True if time is between 23:00 and 06:00."""
         hour = int(self.day_fraction * 24)
-        return hour < 3
+        return hour >= 23 or hour < 6
 
     @property
     def time_of_day(self) -> str:

--- a/tests/test_day_night.py
+++ b/tests/test_day_night.py
@@ -5,9 +5,9 @@ from src.building import Building
 
 def test_world_day_night_toggle():
     world = World(tick_rate=10, day_length=24)
+    world.tick_count = 23
     assert world.is_night
-    for _ in range(3):
-        world.tick()
+    world.tick_count = 6
     assert not world.is_night
 
 
@@ -17,17 +17,12 @@ def test_world_time_of_day():
     assert world.time_of_day == "12:00"
 
 
-def test_villager_sleeps_at_night():
+def test_villager_slow_at_night():
     game = Game(seed=1)
     vill = game.entities[0]
-    bp = game.blueprints["House"]
-    house = Building(bp, vill.position)
-    house.progress = bp.build_time
-    house.passable = True
-    game.buildings.append(house)
-    house.residents.append(vill.id)
-    vill.home = house.position
-    game.world.tick_count = game.world.day_length // 24
-    vill.update(game)
-    assert vill.asleep
-    assert vill.state == "sleeping"
+    base = 10
+    game.world.tick_count = game.world.day_length // 2
+    day_delay = vill._action_delay(game, base)
+    game.world.tick_count = game.world.day_length * 23 // 24
+    night_delay = vill._action_delay(game, base)
+    assert night_delay >= int(day_delay * 1.5)


### PR DESCRIPTION
## Summary
- remove villager sleep behaviour
- slow villager actions by 50% between 23:00 and 06:00
- adjust nighttime detection period
- update tests for new slowdown logic

## Testing
- `venv/bin/pytest tests/test_day_night.py -q`
- `venv/bin/pytest -q`
