### PR TITLE
Improve resource allocation spacing

### DIFF
--- a/src/villager.py
+++ b/src/villager.py
@@ -347,6 +347,8 @@ class Villager:
                     game.buildings,
                     search_limit=game.get_search_limit(),
                     avoid=avoid,
+                    spacing=3,
+                    area=10,
                 )
                 if pos is None or not game.reserve_resource(pos, self.id, resource_type):
                     self._wander(game)


### PR DESCRIPTION
## Summary
- add spacing logic to find_nearest_resource to spread villagers across resources
- use the spacing-enhanced function in villager gather logic

## Testing
- `pytest -q`