### PR TITLE
Improve job balancing and pathfinder randomness

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -267,12 +267,11 @@ class Game:
                 vill.role = role
                 counts[role].append(vill)
 
-        wood_need = max(0, self.wood_threshold - self.storage.get("wood", 0))
-        stone_need = max(0, self.stone_threshold - self.storage.get("stone", 0))
-        preferred = Role.WOODCUTTER if wood_need >= stone_need else Role.MINER
-
-        for v in unassigned:
-            v.role = preferred
+        while unassigned:
+            role = min(mandatory, key=lambda r: len(counts.get(r, [])))
+            vill = unassigned.pop()
+            vill.role = role
+            counts[role].append(vill)
 
     # --- Usage Tracking ---------------------------------------------
     def record_tile_usage(self, pos: Tuple[int, int]) -> None:

--- a/src/pathfinding.py
+++ b/src/pathfinding.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import heapq
 import logging
+import random
 from dataclasses import dataclass, field
 from typing import Dict, Iterable, List, Optional, Set, Tuple
 
@@ -20,14 +21,18 @@ class _Node:
 
 def _neighbors(pos: Tuple[int, int], gmap: GameMap) -> Iterable[Tuple[int, int]]:
     x, y = pos
+    neighbors: List[Tuple[int, int]] = []
     if x > 0:
-        yield (x - 1, y)
+        neighbors.append((x - 1, y))
     if x < gmap.width - 1:
-        yield (x + 1, y)
+        neighbors.append((x + 1, y))
     if y > 0:
-        yield (x, y - 1)
+        neighbors.append((x, y - 1))
     if y < gmap.height - 1:
-        yield (x, y + 1)
+        neighbors.append((x, y + 1))
+    random.shuffle(neighbors)
+    for n in neighbors:
+        yield n
 
 
 def _passable(pos: Tuple[int, int], gmap: GameMap, buildings: Iterable[object]) -> bool:

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -23,3 +23,17 @@ def test_woodcutter_gathers_wood():
     job = game.dispatch_job(woodcutter)
     assert job.type == "gather"
     assert job.payload == TileType.TREE
+
+
+def test_roles_distributed_evenly():
+    game = Game(seed=1)
+    for _ in range(11):
+        game._spawn_villager(game.townhall_pos, age=18, stage=LifeStage.ADULT)
+    game._update_roles()
+    mandatory = [Role.BUILDER, Role.WOODCUTTER, Role.MINER, Role.ROAD_PLANNER]
+    counts = {role: 0 for role in mandatory}
+    for v in game.entities:
+        if v.role in counts:
+            counts[v.role] += 1
+    values = list(counts.values())
+    assert max(values) - min(values) <= 1


### PR DESCRIPTION
## Summary
- distribute villager job roles evenly
- randomize neighbor expansion in pathfinding
- test for even role distribution

## Testing
- `pytest -q`
- `pytest -q tests/test_roles.py::test_roles_distributed_evenly -q`