### PR TITLE
Add color toggle & space glyph for grass

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -43,7 +43,9 @@ class Job:
 class Game:
     """Owns game state and runs the main loop."""
 
-    def __init__(self, seed: int | None = None, preview: bool = False) -> None:
+    def __init__(
+        self, seed: int | None = None, preview: bool = False, *, use_color: bool = True
+    ) -> None:
         random.seed(seed)
         self.map = GameMap(seed=seed)
         if preview:
@@ -137,7 +139,7 @@ class Game:
         self.tile_usage: Dict[Tuple[int, int], int] = defaultdict(int)
         self.reservations: Dict[Tuple[int, int], Tuple[int, TileType]] = {}
 
-        self.renderer = Renderer()
+        self.renderer = Renderer(use_color=use_color)
         self.camera = Camera()
         # Start zoomed in
         self.camera.set_zoom_level(0)
@@ -522,10 +524,7 @@ class Game:
         q = deque(starts)
         searched = 0
         neighbourhood = [
-            (dx, dy)
-            for dx in range(-1, 2)
-            for dy in range(-1, 2)
-            if (dx, dy) != (0, 0)
+            (dx, dy) for dx in range(-1, 2) for dy in range(-1, 2) if (dx, dy) != (0, 0)
         ]
         while q and searched < SEARCH_LIMIT:
             p = q.popleft()

--- a/src/main.py
+++ b/src/main.py
@@ -19,11 +19,12 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--preview", action="store_true", help="Show world preview during startup"
     )
+    parser.add_argument("--no-color", action="store_true", help="Disable colour output")
     args = parser.parse_args(argv)
 
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
 
-    game = Game(seed=args.seed, preview=args.preview)
+    game = Game(seed=args.seed, preview=args.preview, use_color=not args.no_color)
     game.run(show_fps=args.show_fps)
 
 


### PR DESCRIPTION
## Summary
- allow Renderer to toggle colour output
- output space for grass when zoomed out
- expose `--no-color` CLI flag and propagate through Game
- test colourless rendering behaviour
- map RGB colours to ANSI 256 when applying colours

## Testing
- `venv/bin/pytest -q`
