### PR TITLE
Implement discrete day/night hues and day counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 **VillageSim** is a real‑time, terminal‑based medieval village simulator written entirely in Python. A procedurally generated **1 000 × 1 000‑tile** world—lush grasslands, dense forests, rugged stone outcrops, and meandering rivers—comes alive in nothing but Unicode glyphs.  From the first swing of an axe to the rise of a bustling hamlet, every moment is driven by an agent‑based simulation that plays out before your eyes at **around 60 ticks per second by default**.
 The day/night cycle now stretches to roughly **24 seconds per day**, four times longer than before, giving you more time to watch villagers go about their business.
+Lighting now uses a four-step hue cycle (night, morning, afternoon and evening) instead of a continuous fade, so colours shift discretely throughout the day.
 
 Rather than micromanaging individual settlers, you watch emergent stories unfold.  Each villager is an autonomous entity that can plan paths, gather resources, construct buildings, and deliver supplies back to storage, all while navigating a living landscape that reacts to their actions.  A simple finite‑state machine turns a lone labourer into a self‑sufficient workforce that knows when to chop, haul, build, and rest.
 
@@ -68,8 +69,8 @@ $ python3 -m src.main [--seed 42] [--show-fps] [-v]
 | `h`       | Toggle help pane |
 | `q`       | Quit             |
 
-The bottom row shows the current tick, camera position/zoom, stored resources
-and population. Use `--show-fps` to display performance metrics. Pass `-v` to
+The bottom row shows the current tick, current day, camera position/zoom,
+stored resources and population. Use `--show-fps` to display performance metrics. Pass `-v` to
 enable debug logging which now reports render timing and lighting cost.
 
 ---

--- a/src/filters.py
+++ b/src/filters.py
@@ -63,16 +63,30 @@ def apply_lighting(
 
 
 def day_night_filter(color: ColorRGB, tile: Tile, day_fraction: float) -> ColorRGB:
-    """Darken or lighten ``color`` based on ``day_fraction``.
+    """Apply a simple four-step colour cycle based on ``day_fraction``.
 
-    ``day_fraction`` should be in ``[0,1]`` where ``0`` is midnight and ``0.5``
-    is noon.
+    Instead of gradually fading colours, the world now shifts through four
+    distinct tints:
+
+    ``00:00-06:00`` (night), ``06:00-12:00`` (morning), ``12:00-18:00``
+    (afternoon) and ``18:00-00:00`` (evening).  The night tint is less dark than
+    before to keep the scene visible.
     """
+
     hour = int(day_fraction * 24)
-    hour_fraction = hour / 24
-    brightness = 0.3 + 0.7 * math.sin(math.pi * hour_fraction)
-    r, g, b = color
-    return (int(r * brightness), int(g * brightness), int(b * brightness))
+    if 0 <= hour < 6:  # Night - subtle blue tint
+        tint = (0.6, 0.7, 1.0)
+    elif 6 <= hour < 12:  # Morning - slight warm tint
+        tint = (1.1, 1.0, 0.9)
+    elif 12 <= hour < 18:  # Afternoon - neutral
+        tint = (1.0, 1.0, 1.0)
+    else:  # Evening - orange hue
+        tint = (1.1, 0.9, 0.8)
+
+    r = min(255, int(color[0] * tint[0]))
+    g = min(255, int(color[1] * tint[1]))
+    b = min(255, int(color[2] * tint[2]))
+    return (r, g, b)
 
 
 def zone_filter(color: ColorRGB, tile: Tile, day_fraction: float) -> ColorRGB:

--- a/src/game.py
+++ b/src/game.py
@@ -959,6 +959,7 @@ class Game:
         )
         status = (
             f"Tick:{self.tick_count} "
+            f"Day:{self.world.day} "
             f"Time:{self.world.time_of_day} "
             f"Cam:{self.camera.x},{self.camera.y} "
             f"Zoom:{self.camera.zoom} "

--- a/tests/test_lighting.py
+++ b/tests/test_lighting.py
@@ -6,7 +6,7 @@ from src.constants import TileType, ZoneType
 def test_day_night_filter_darkens():
     colour = (100, 100, 100)
     result = day_night_filter(colour, Tile(TileType.GRASS), 0.0)
-    assert result == (30, 30, 30)
+    assert result == (60, 70, 100)
 
 
 def test_zone_filter_tints():


### PR DESCRIPTION
## Summary
- implement a four-step hue-based day/night cycle
- show the current day on the status line
- document the hue cycle and day counter in the README
- update lighting unit test for new colours

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*