### PR TITLE
Introduce idle wandering for villagers

### DIFF
--- a/src/villager.py
+++ b/src/villager.py
@@ -111,9 +111,7 @@ class Villager:
         self.mood = levels[idx]
 
     # ------------------------------------------------------------------
-    def _move_away_from(
-        self, other: Tuple[int, int], game: "Game"
-    ) -> bool:
+    def _move_away_from(self, other: Tuple[int, int], game: "Game") -> bool:
         """Step one tile away from ``other`` if possible."""
 
         options = []
@@ -307,6 +305,9 @@ class Villager:
         if self._avoid_nearby_villagers(game):
             return
         if self.state == "idle":
+            if random.random() < 0.2:
+                self._wander(game)
+                return
             job = game.dispatch_job(self)
             if not job:
                 self.adjust_mood(-1)
@@ -350,7 +351,9 @@ class Villager:
                     spacing=3,
                     area=10,
                 )
-                if pos is None or not game.reserve_resource(pos, self.id, resource_type):
+                if pos is None or not game.reserve_resource(
+                    pos, self.id, resource_type
+                ):
                     self._wander(game)
                     return
                 self.resource_type = resource_type

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import random
+import pytest
+import src.villager as villager_mod
+
+
+@pytest.fixture(autouse=True)
+def disable_random_wander(monkeypatch):
+    monkeypatch.setattr(villager_mod.random, "random", lambda: 1.0)
+    yield

--- a/tests/test_wander.py
+++ b/tests/test_wander.py
@@ -16,3 +16,25 @@ def test_villager_wanders_when_search_fails(monkeypatch):
 
     vill.update(game)
     assert vill.position != start
+
+
+def test_villager_may_wander_when_idle(monkeypatch):
+    game = Game(seed=1)
+    vill = game.entities[0]
+    start = vill.position
+
+    monkeypatch.setattr(villager_mod.random, "random", lambda: 0.1)
+    monkeypatch.setattr(villager_mod.random, "shuffle", lambda x: None)
+
+    called = {"dispatch": False}
+
+    def fake_dispatch(self, _):
+        called["dispatch"] = True
+        return None
+
+    monkeypatch.setattr(Game, "dispatch_job", fake_dispatch)
+
+    vill.update(game)
+
+    assert not called["dispatch"]
+    assert vill.position != start


### PR DESCRIPTION
## Summary
- make villagers occasionally wander when idle instead of taking a job
- add a minimal DummyTerminal to use when blessed is missing
- ensure tests patch out the random wandering by default
- test that wandering can occur before job dispatch

## Testing
- `pytest -q`