### PR TITLE
Add storage capacity bonus

### DIFF
--- a/src/blueprints/storage.py
+++ b/src/blueprints/storage.py
@@ -11,5 +11,6 @@ BLUEPRINT = BuildingBlueprint(
     color=Color.BUILDING,
     wood=20,
     stone=20,
+    capacity_bonus=50,
     passable=True,
 )

--- a/src/building.py
+++ b/src/building.py
@@ -19,6 +19,7 @@ class BuildingBlueprint:
     stone: int = 0
     capacity: int = 0
     efficiency: float = 1.0
+    capacity_bonus: int = 0
     # If True the completed building can be walked over
     passable: bool = False
 

--- a/src/game.py
+++ b/src/game.py
@@ -306,6 +306,10 @@ class Game:
 
     def _assign_builder(self, building: Building, role: Role = Role.BUILDER) -> None:
         """Assign the nearest villager with ``role`` to construct ``building``."""
+        if building.complete:
+            if building.blueprint.name == "Storage":
+                self.storage_capacity += building.blueprint.capacity_bonus
+            return
         if not self.entities:
             return
         candidates = [v for v in self.entities if v.role is role]
@@ -970,6 +974,7 @@ class Game:
             day_fraction=self.world.day_fraction,
             reserved=set(self.reservations.keys()),
         )
+        used_capacity = sum(self.storage.values())
         status = (
             f"Tick:{self.tick_count} "
             f"Day:{self.world.day} "
@@ -979,7 +984,7 @@ class Game:
             f"Wood:{self.storage['wood']} "
             f"Stone:{self.storage['stone']} "
             f"Food:{self.storage['food']} "
-            f"Cap:{self.storage_capacity} "
+            f"Cap:{used_capacity}/{self.storage_capacity} "
             f"Pop:{len(self.entities)}"
         )
         counts: Dict[Role, int] = defaultdict(int)

--- a/src/villager.py
+++ b/src/villager.py
@@ -589,6 +589,8 @@ class Villager:
                         j for j in game.jobs if j.payload is not self.target_building
                     ]
                     self.target_building.builder_id = None
+                    if self.target_building.blueprint.name == "Storage":
+                        game.storage_capacity += self.target_building.blueprint.capacity_bonus
                     if self.target_building.blueprint.name == "House":
                         game.schedule_spawn(self.target_building.position)
                 else:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,37 @@
+def test_storage_capacity_increases_after_completion():
+    from src.game import Game
+    from src.building import Building
+
+    game = Game(seed=1)
+    vill = game.entities[0]
+    bp = game.blueprints["Storage"]
+    bp.build_time = 1
+    pos = (vill.x + 1, vill.y)
+    b = Building(bp, pos)
+    game.buildings.append(b)
+    game.build_queue.append(b)
+    game._assign_builder(b)
+
+    prev = game.storage_capacity
+    vill.state = "build"
+    vill.target_building = b
+    vill.target_path = []
+    vill.update(game)
+
+    assert b.complete
+    assert game.storage_capacity == prev + bp.capacity_bonus
+
+def test_assign_builder_immediate_storage_adds_capacity():
+    from src.game import Game
+    from src.building import Building
+
+    game = Game(seed=1)
+    vill = game.entities[0]
+    bp = game.blueprints["Storage"]
+    pos = (vill.x + 1, vill.y)
+    b = Building(bp, pos, progress=bp.build_time)
+    game.buildings.append(b)
+    prev = game.storage_capacity
+    game._assign_builder(b)
+    assert game.storage_capacity == prev + bp.capacity_bonus
+


### PR DESCRIPTION
## Summary
- building blueprints support a `capacity_bonus`
- storage buildings add `capacity_bonus=50`
- increase storage capacity when storage buildings finish
- render capacity as used/total
- test storage capacity increases when storage is built

## Testing
- `pytest -q`