### PR TITLE
Implement multi-village expansion

### DIFF
--- a/src/building.py
+++ b/src/building.py
@@ -36,11 +36,13 @@ class Building:
     capacity: int = 0
     efficiency: float = 1.0
     builder_id: int | None = None
+    color: object | None = None
 
     def __post_init__(self) -> None:
         """Initialise stats from the blueprint."""
         self.capacity = self.blueprint.capacity
         self.efficiency = self.blueprint.efficiency
+        self.color = self.blueprint.color
 
     # ---------------------------------------------------------------
     def upgrade_cost(self) -> Tuple[int, int]:
@@ -69,11 +71,11 @@ class Building:
         return self.progress >= self.blueprint.build_time
 
     # ------------------------------------------------------------------
-    def glyph_for_progress(self) -> tuple[str, Color]:
+    def glyph_for_progress(self) -> tuple[str, object]:
         """Return a glyph and colour based on construction progress."""
 
         if self.complete or self.blueprint.build_time <= 0:
-            return self.blueprint.glyph, self.blueprint.color
+            return self.blueprint.glyph, self.color
 
         ratio = self.progress / self.blueprint.build_time
         if ratio < 1 / 3:
@@ -83,4 +85,4 @@ class Building:
         else:
             glyph = self.blueprint.glyph.lower()
 
-        return glyph, self.blueprint.color
+        return glyph, self.color

--- a/src/constants.py
+++ b/src/constants.py
@@ -22,8 +22,9 @@ UI_PANEL_HEIGHT = 10
 VIEWPORT_HEIGHT = 42 - UI_PANEL_HEIGHT
 # Y coordinate where the status line is rendered
 STATUS_PANEL_Y = VIEWPORT_HEIGHT
-# Discrete zoom levels: 1 cell per tile, 2 cells per tile, etc.
-ZOOM_LEVELS = [1, 2, 4]
+# Discrete zoom levels.  Only a single fixed zoom is now used
+# so the camera always renders one cell per tile.
+ZOOM_LEVELS = [1]
 DEFAULT_ZOOM_INDEX = 0
 
 # Game tick rate (ticks per second)
@@ -52,6 +53,21 @@ SEARCH_LIMIT = 50000
 
 # Fixed colour for all UI elements (RGB)
 UI_COLOR_RGB = (255, 255, 255)
+
+# Distinct colours used to differentiate villages.  These are
+# RGB tuples so buildings can override the default palette on a
+# per-village basis.
+VILLAGE_COLORS = [
+    (255, 0, 0),
+    (0, 255, 0),
+    (0, 0, 255),
+    (255, 255, 0),
+    (255, 0, 255),
+    (0, 255, 255),
+    (200, 100, 50),
+    (100, 50, 200),
+    (50, 200, 100),
+]
 
 
 class Color(Enum):

--- a/src/game.py
+++ b/src/game.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 import random
 import time
+import math
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Dict, List, Tuple, Optional
@@ -18,6 +19,7 @@ from .constants import (
     ZoneType,
     LifeStage,
     Role,
+    VILLAGE_COLORS,
 )
 
 from .building import BuildingBlueprint, Building
@@ -81,6 +83,7 @@ class Game:
         townhall.progress = townhall.blueprint.build_time
         townhall.passable = True
         self.buildings.append(townhall)
+        self.townhalls: List[Building] = [townhall]
 
         # Place initial Storage building 5 tiles east of the Town Hall
         candidate = (self.townhall_pos[0] + 5, self.townhall_pos[1])
@@ -784,6 +787,47 @@ class Game:
                 self.buildings.append(building)
                 self._assign_builder(building, Role.BUILDER)
 
+    def _maybe_spawn_new_village(self) -> None:
+        """Occasionally send an explorer to found a new village."""
+        cost = 100 * len(self.townhalls)
+        if (
+            self.storage.get("wood", 0) < cost
+            or self.storage.get("stone", 0) < cost
+            or self.build_queue
+        ):
+            return
+        # Small random chance each tick
+        if random.random() > 0.001:
+            return
+        origin = self.townhalls[-1].position
+        dist = random.randint(500, 1000)
+        angle = random.random() * 6.28318
+        tx = max(0, min(self.map.width - 1, origin[0] + int(dist * math.cos(angle))))
+        ty = max(0, min(self.map.height - 1, origin[1] + int(dist * math.sin(angle))))
+        pos = self._find_nearest_passable((tx, ty))
+        color = VILLAGE_COLORS[(len(self.townhalls)) % len(VILLAGE_COLORS)]
+        bp = BuildingBlueprint(
+            name=f"TownHall{len(self.townhalls)+1}",
+            build_time=10,
+            footprint=[(0, 0)],
+            glyph="H",
+            color=color,
+            wood=cost,
+            stone=cost,
+            passable=True,
+        )
+        building = Building(bp, pos)
+        self.build_queue.append(building)
+        self.buildings.append(building)
+        self.townhalls.append(building)
+        self.storage["wood"] -= cost
+        self.storage["stone"] -= cost
+        explorer = Villager(id=self.next_entity_id, position=origin, role=Role.BUILDER)
+        self.next_entity_id += 1
+        self.entities.append(explorer)
+        building.builder_id = explorer.id
+        self.jobs.append(Job("build", building, target_villager=explorer.id))
+
     # --- Game Loop -----------------------------------------------------
     def run(self, show_fps: bool = False) -> None:
         """Run the main loop until quit."""
@@ -857,9 +901,11 @@ class Game:
                     self.camera.move(0, 0, self.map.width, self.map.height)
                     self.pan_pause = 240
                 elif ord("1") <= key <= ord("9"):
-                    self.camera.set_zoom_level(key - ord("1"))
-                    self.camera.move(0, 0, self.map.width, self.map.height)
-                    self.pan_pause = 240
+                    idx = key - ord("1")
+                    if idx < len(self.townhalls):
+                        pos = self.townhalls[idx].position
+                        self.camera.center_on(pos[0], pos[1], self.map.width, self.map.height)
+                        self.pan_pause = 240
                 elif key == ord(" "):
                     self.paused = not self.paused
                 elif key == ord("."):
@@ -896,9 +942,11 @@ class Game:
                     self.camera.move(0, 0, self.map.width, self.map.height)
                     self.pan_pause = 240
                 elif key in "123456789":
-                    self.camera.set_zoom_level(int(key) - 1)
-                    self.camera.move(0, 0, self.map.width, self.map.height)
-                    self.pan_pause = 240
+                    idx = int(key) - 1
+                    if idx < len(self.townhalls):
+                        pos = self.townhalls[idx].position
+                        self.camera.center_on(pos[0], pos[1], self.map.width, self.map.height)
+                        self.pan_pause = 240
                 elif key == " ":
                     self.paused = not self.paused
                 elif key == ".":
@@ -936,6 +984,7 @@ class Game:
         self._auto_upgrade()
         self._plan_townhall_progress()
         self._expand_housing()
+        self._maybe_spawn_new_village()
 
     def render(self) -> None:
         """Draw the current game state."""
@@ -1006,7 +1055,7 @@ class Game:
                 "h - toggle help",
                 "b - toggle buildings",
                 "q - quit",
-                "1-9 - set zoom",
+                "1-9 - centre on village",
                 "A - toggle thoughts",
             ]
             self.renderer.render_help(lines, start_y=overlay_start)

--- a/src/renderer.py
+++ b/src/renderer.py
@@ -266,7 +266,7 @@ class Renderer:
                     if callable(render_fn):
                         glyph, color = render_fn()
                     else:
-                        glyph, color = b.blueprint.glyph, b.blueprint.color
+                        glyph, color = b.blueprint.glyph, getattr(b, "color", b.blueprint.color)
 
                     if b.blueprint.name == "Road" and getattr(b, "complete", False):
                         n = any(


### PR DESCRIPTION
## Summary
- support only a single zoom level
- provide distinct colours for villages
- allow buildings to override colour
- spawn explorers to establish distant town halls
- remap numeric keys to focus the camera on each town hall

## Testing
- `pytest -q`